### PR TITLE
feat(help): add role-aware Help Center with interactive walkthrough

### DIFF
--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Box, Tabs, Tab } from '@mui/material';
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
+import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded';
+import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
+import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
+import RocketLaunchOutlinedIcon from '@mui/icons-material/RocketLaunchOutlined';
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
+import { Role } from '@/types/User';
+import { useTour } from '@/contexts/TourContext';
+import {
+  HELP_GUIDES,
+  HELP_ROLE_ORDER,
+  HelpGuide,
+  HelpRoleKey,
+  HelpSection,
+} from './content';
+
+const roleToKey = (role: Role | string | undefined): HelpRoleKey => {
+  switch (role) {
+    case 'faculty':
+      return 'faculty';
+    case 'admin':
+      return 'admin';
+    default:
+      return 'student';
+  }
+};
+
+type HelpViewProps = {
+  role: Role | string | undefined;
+};
+
+const HelpView: React.FC<HelpViewProps> = ({ role }) => {
+  const defaultKey = useMemo(() => roleToKey(role), [role]);
+  const [activeKey, setActiveKey] = useState<HelpRoleKey>(defaultKey);
+  const [openSection, setOpenSection] = useState<string | null>(null);
+  const { start } = useTour();
+
+  const guide: HelpGuide = HELP_GUIDES[activeKey];
+  const activeIndex = HELP_ROLE_ORDER.indexOf(activeKey);
+
+  return (
+    <div className="pb-16">
+      {/* Intro card */}
+      <div className="rounded-2xl border border-[#E7E1F7] bg-gradient-to-br from-[#F7F4FF] to-white p-6 md:p-8 mb-8 shadow-[0_1px_0_rgba(45,15,131,0.04)]">
+        <div className="flex items-start gap-4">
+          <div className="w-11 h-11 rounded-xl bg-[#5A41D8] text-white flex items-center justify-center shrink-0">
+            <HelpOutlineOutlinedIcon />
+          </div>
+          <div>
+            <p className="text-xs font-semibold tracking-wider text-[#6C37D8] uppercase">
+              Help Center
+            </p>
+            <h2 className="text-2xl md:text-[28px] font-semibold text-[#1E1442] mt-1">
+              Get up to speed with CourseConnect
+            </h2>
+            <p className="mt-2 text-sm md:text-[15px] text-[#4A3F6B] leading-relaxed max-w-3xl">
+              Pick your role below to see step-by-step instructions for every
+              feature you use. Your own role is selected by default — switch
+              tabs any time to see what the other roles experience.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Walkthrough CTA */}
+      <div className="rounded-2xl bg-gradient-to-br from-[#2d0f83] via-[#5A41D8] to-[#6C37D8] text-white p-6 md:p-7 mb-8 shadow-[0_20px_45px_-20px_rgba(45,15,131,0.55)] flex flex-col md:flex-row md:items-center gap-5">
+        <div className="shrink-0 w-12 h-12 rounded-xl bg-white/15 backdrop-blur flex items-center justify-center">
+          <AutoAwesomeOutlinedIcon sx={{ fontSize: 26 }} />
+        </div>
+        <div className="flex-1">
+          <p className="text-[11px] font-semibold tracking-[0.18em] uppercase text-white/80">
+            Interactive tour
+          </p>
+          <h3 className="text-[19px] md:text-[21px] font-semibold mt-0.5">
+            Take a 60-second walkthrough of CourseConnect
+          </h3>
+          <p className="text-sm text-white/85 mt-1.5 leading-relaxed max-w-2xl">
+            Guided tooltips spotlight the most important features for your role:
+            where to apply, where to review, and where to find every update.
+            Press{' '}
+            <kbd className="px-1.5 py-0.5 rounded bg-white/20 text-xs font-mono">
+              Esc
+            </kbd>{' '}
+            any time to exit.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => start(activeKey)}
+          className="shrink-0 inline-flex items-center justify-center gap-2 bg-white text-[#2d0f83] hover:bg-[#F4F1FC] font-semibold px-5 py-2.5 rounded-full shadow-[0_6px_20px_rgba(0,0,0,0.18)] transition-colors"
+        >
+          <PlayArrowRoundedIcon sx={{ fontSize: 20 }} />
+          Start walkthrough
+        </button>
+      </div>
+
+      {/* Role tabs */}
+      <Box
+        sx={{
+          display: 'inline-flex',
+          p: 0.5,
+          mb: 4,
+          backgroundColor: '#F4F1FC',
+          borderRadius: '999px',
+        }}
+      >
+        <Tabs
+          value={activeIndex}
+          onChange={(_, v) => setActiveKey(HELP_ROLE_ORDER[v])}
+          TabIndicatorProps={{ sx: { display: 'none' } }}
+          sx={{
+            minHeight: 'auto',
+            '& .MuiTabs-flexContainer': { gap: 0.5 },
+            '& .MuiTab-root': {
+              textTransform: 'none',
+              fontWeight: 600,
+              fontSize: '0.88rem',
+              minHeight: 36,
+              py: 0.75,
+              px: 2.5,
+              borderRadius: '999px',
+              color: '#6B5AA8',
+              transition: 'all 0.15s ease',
+            },
+            '& .Mui-selected': {
+              color: '#fff !important',
+              backgroundColor: '#5A41D8',
+              boxShadow: '0 4px 12px rgba(90, 65, 216, 0.24)',
+            },
+          }}
+        >
+          {HELP_ROLE_ORDER.map((key) => (
+            <Tab
+              key={key}
+              label={
+                key === defaultKey
+                  ? `${HELP_GUIDES[key].label} (you)`
+                  : HELP_GUIDES[key].label
+              }
+            />
+          ))}
+        </Tabs>
+      </Box>
+
+      {/* Overview */}
+      <section className="mb-10">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="inline-block w-1 h-5 rounded-full bg-[#5A41D8]" />
+          <h3 className="text-lg font-semibold text-[#1E1442]">
+            {guide.label} overview
+          </h3>
+        </div>
+        <p className="text-[#6B5AA8] text-sm md:text-[15px] max-w-3xl">
+          {guide.tagline}
+        </p>
+        <p className="mt-3 text-[#4A3F6B] text-sm md:text-[15px] leading-relaxed max-w-3xl">
+          {guide.overview}
+        </p>
+      </section>
+
+      {/* Quick start */}
+      <section className="mb-10">
+        <div className="flex items-center gap-2 mb-3">
+          <RocketLaunchOutlinedIcon sx={{ color: '#5A41D8', fontSize: 20 }} />
+          <h3 className="text-lg font-semibold text-[#1E1442]">Quick start</h3>
+        </div>
+        <ol className="grid md:grid-cols-2 gap-3">
+          {guide.quickStart.map((step, i) => (
+            <li
+              key={i}
+              className="rounded-xl border border-[#E7E1F7] bg-white p-4 flex items-start gap-3"
+            >
+              <span className="shrink-0 w-7 h-7 rounded-full bg-[#F4F1FC] text-[#5A41D8] text-sm font-semibold flex items-center justify-center">
+                {i + 1}
+              </span>
+              <span className="text-sm text-[#2E2551] leading-relaxed">
+                {step}
+              </span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Feature sections */}
+      <section className="mb-12">
+        <div className="flex items-center gap-2 mb-4">
+          <span className="inline-block w-1 h-5 rounded-full bg-[#5A41D8]" />
+          <h3 className="text-lg font-semibold text-[#1E1442]">
+            How to use each feature
+          </h3>
+        </div>
+        <div className="grid gap-3">
+          {guide.sections.map((section) => (
+            <FeatureCard
+              key={section.id}
+              section={section}
+              isOpen={openSection === section.id}
+              onToggle={() =>
+                setOpenSection((curr) =>
+                  curr === section.id ? null : section.id
+                )
+              }
+              isOwnRole={activeKey === defaultKey}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <span className="inline-block w-1 h-5 rounded-full bg-[#5A41D8]" />
+          <h3 className="text-lg font-semibold text-[#1E1442]">
+            Frequently asked questions
+          </h3>
+        </div>
+        <div className="grid gap-3">
+          {guide.faqs.map((faq, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-[#E7E1F7] bg-white p-5"
+            >
+              <p className="text-sm font-semibold text-[#1E1442]">{faq.q}</p>
+              <p className="text-sm text-[#4A3F6B] mt-1.5 leading-relaxed">
+                {faq.a}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+type FeatureCardProps = {
+  section: HelpSection;
+  isOpen: boolean;
+  onToggle: () => void;
+  isOwnRole: boolean;
+};
+
+const FeatureCard: React.FC<FeatureCardProps> = ({
+  section,
+  isOpen,
+  onToggle,
+  isOwnRole,
+}) => {
+  const Icon = section.icon;
+  return (
+    <div className="rounded-xl border border-[#E7E1F7] bg-white overflow-hidden transition-shadow duration-200 hover:shadow-[0_8px_24px_-12px_rgba(90,65,216,0.25)]">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-start gap-4 p-5 text-left"
+        aria-expanded={isOpen}
+      >
+        <div className="shrink-0 w-10 h-10 rounded-lg bg-[#F4F1FC] text-[#5A41D8] flex items-center justify-center">
+          <Icon fontSize="small" />
+        </div>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h4 className="text-[15px] font-semibold text-[#1E1442]">
+              {section.title}
+            </h4>
+          </div>
+          <p className="text-sm text-[#6B5AA8] mt-1 leading-relaxed">
+            {section.summary}
+          </p>
+        </div>
+        <span
+          aria-hidden
+          className={`shrink-0 text-[#6B5AA8] mt-2 transition-transform duration-200 ${
+            isOpen ? 'rotate-90' : ''
+          }`}
+        >
+          <ArrowForwardRoundedIcon fontSize="small" />
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="px-5 pb-5 pt-0 border-t border-[#F0EBFB]">
+          <ol className="mt-4 space-y-2.5">
+            {section.steps.map((step, i) => (
+              <li key={i} className="flex items-start gap-3">
+                <CheckCircleOutlineRoundedIcon
+                  sx={{ color: '#5A41D8', fontSize: 18, mt: '2px' }}
+                />
+                <span className="text-sm text-[#2E2551] leading-relaxed">
+                  {step}
+                </span>
+              </li>
+            ))}
+          </ol>
+
+          {section.tips && section.tips.length > 0 && (
+            <div className="mt-4 rounded-lg bg-[#FBF9FF] border border-[#EFE8FB] p-3.5">
+              <div className="flex items-center gap-2 mb-2">
+                <LightbulbOutlinedIcon
+                  sx={{ color: '#5A41D8', fontSize: 18 }}
+                />
+                <span className="text-xs font-semibold uppercase tracking-wider text-[#5A41D8]">
+                  Tips
+                </span>
+              </div>
+              <ul className="space-y-1.5">
+                {section.tips.map((tip, i) => (
+                  <li
+                    key={i}
+                    className="text-sm text-[#4A3F6B] leading-relaxed"
+                  >
+                    • {tip}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {section.path && isOwnRole && (
+            <div className="mt-4">
+              <Link
+                href={section.path}
+                className="inline-flex items-center gap-1.5 text-sm font-semibold text-[#5A41D8] hover:text-[#2d0f83] transition-colors"
+              >
+                Open {section.title}
+                <ArrowForwardRoundedIcon fontSize="small" />
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HelpView;

--- a/src/app/help/content.ts
+++ b/src/app/help/content.ts
@@ -1,0 +1,366 @@
+import { SvgIconComponent } from '@mui/icons-material';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import CheckBoxOutlinedIcon from '@mui/icons-material/CheckBoxOutlined';
+import CampaignOutlinedIcon from '@mui/icons-material/CampaignOutlined';
+import BookOutlinedIcon from '@mui/icons-material/BookOutlined';
+import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined';
+import BarChartOutlinedIcon from '@mui/icons-material/BarChartOutlined';
+import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
+
+export type HelpRoleKey = 'student' | 'faculty' | 'admin';
+
+export type HelpSection = {
+  id: string;
+  title: string;
+  icon: SvgIconComponent;
+  path?: string;
+  summary: string;
+  steps: string[];
+  tips?: string[];
+};
+
+export type HelpGuide = {
+  key: HelpRoleKey;
+  label: string;
+  tagline: string;
+  overview: string;
+  quickStart: string[];
+  sections: HelpSection[];
+  faqs: { q: string; a: string }[];
+};
+
+export const STUDENT_GUIDE: HelpGuide = {
+  key: 'student',
+  label: 'Student',
+  tagline: 'Apply for assistantships, browse research, and track your status.',
+  overview:
+    'As a student you can apply to be a Course Assistant, apply for Supervised Teaching (EEL 6940), browse and apply to faculty research positions, and follow every decision in one place.',
+  quickStart: [
+    'Open the Dashboard from the ECE logo in the top-left to see every tool available to you.',
+    'Go to Applications to start a Course Assistant or Supervised Teaching application.',
+    'Visit Research to browse open faculty positions and submit interest.',
+    'Use Status to monitor decisions, and check Announcements (bell icon) for updates.',
+  ],
+  sections: [
+    {
+      id: 'applications',
+      title: 'Applications',
+      icon: DescriptionOutlinedIcon,
+      path: '/applications',
+      summary:
+        'Choose between Course Assistant (undergraduate / MS TA) and Supervised Teaching (PhD EEL 6940) and submit a complete application.',
+      steps: [
+        'Open Applications from the sidebar and pick Course Assistant or Supervised Teaching.',
+        'Fill in your personal info: name, UF email, UFID, phone, department, and GPA.',
+        'Course Assistant: choose your degree level, semester status, position type, and weekly availability (7, 14, or 20 hrs). Multi-select the courses you would like to assist, paste a Google Drive link to your resume, and write your qualifications statement.',
+        'Supervised Teaching: list your advisor and candidacy status, indicate prior EEL 6940 registrations, list courses you can teach, and rank your three teaching-area preferences.',
+        'Complete the CAPTCHA and press Submit. You will receive a confirmation email and your role will update to "Applied."',
+      ],
+      tips: [
+        'You can resubmit — the latest submission replaces the previous one on the same application.',
+        'Only UF email addresses are accepted.',
+      ],
+    },
+    {
+      id: 'research',
+      title: 'Research',
+      icon: ScienceOutlinedIcon,
+      path: '/Research',
+      summary:
+        'Browse faculty research positions and apply to the ones that fit.',
+      steps: [
+        'Open Research to see every open listing.',
+        'Filter by Department and Student Level, or search by keyword to narrow results.',
+        'Click a project card to read the full description, mentor, contact, and terms available.',
+        'Submit your interest from the project detail dialog; the faculty mentor is notified automatically.',
+      ],
+      tips: [
+        'Keep an eye on "Terms Available" — some listings are single-semester only.',
+      ],
+    },
+    {
+      id: 'status',
+      title: 'Status',
+      icon: CheckBoxOutlinedIcon,
+      path: '/status',
+      summary:
+        'A single dashboard of every application you have submitted and every decision made on it.',
+      steps: [
+        'Open Status from the sidebar.',
+        'Each row shows the position type, course, semester, date applied, and current decision (Applied, Approved, Denied, or Accepted).',
+        'If you have no submissions yet, the page shows a friendly "No applications or assignments" message.',
+      ],
+    },
+    {
+      id: 'announcements',
+      title: 'Announcements',
+      icon: CampaignOutlinedIcon,
+      path: '/announcements',
+      summary:
+        'Department announcements in one inbox, with unread tracking and acknowledgments.',
+      steps: [
+        'Open Announcements from the sidebar or the bell icon in the top bar.',
+        'Unread items sit at the top; click any item to read the full message.',
+        'Use "Mark as read / unread" on a single item, or "Mark all read" to clear the list.',
+        'If an announcement requires acknowledgment, you must click the acknowledge button before it is dismissed.',
+      ],
+      tips: ['The red number on the bell is your unread count.'],
+    },
+    {
+      id: 'profile',
+      title: 'Profile',
+      icon: AccountCircleOutlinedIcon,
+      path: '/Profile',
+      summary: 'Review your account info and role.',
+      steps: [
+        'Click your avatar in the top-right to open your profile.',
+        'Check that your name, email, department, UFID, and role are correct.',
+        'Contact the department if anything is wrong — profile edits are handled by admins.',
+      ],
+    },
+  ],
+  faqs: [
+    {
+      q: 'Can I apply to Course Assistant and Supervised Teaching at the same time?',
+      a: 'Yes. They are separate applications and are reviewed independently.',
+    },
+    {
+      q: 'How will I know when I have been accepted?',
+      a: 'Decisions appear on the Status page, and acceptance notices go to your UF email.',
+    },
+    {
+      q: 'Can I edit an application after submitting?',
+      a: 'Submit again with the corrected info — the new submission replaces the old one.',
+    },
+  ],
+};
+
+export const FACULTY_GUIDE: HelpGuide = {
+  key: 'faculty',
+  label: 'Faculty',
+  tagline:
+    'Review applicants, manage your courses, and post research positions.',
+  overview:
+    'Faculty members review TA and Supervised Teaching applicants for their courses, manage course rosters, post research opportunities, and broadcast announcements.',
+  quickStart: [
+    'Open Applications to see students who applied to courses you teach.',
+    'Open Courses to review your current and past semester assignments.',
+    'Open Research to post a new position or manage existing ones.',
+    'Use Announcements to broadcast updates to students, other faculty, or specific users.',
+  ],
+  sections: [
+    {
+      id: 'applications',
+      title: 'Applications',
+      icon: DescriptionOutlinedIcon,
+      path: '/applications',
+      summary:
+        'Review the students who applied to courses you teach, with full application details attached.',
+      steps: [
+        'Open Applications from the sidebar.',
+        'Browse the list of applicants matched to your courses; click a row to see the full application, resume link, and qualifications.',
+        'Use the filters to narrow by semester or status.',
+      ],
+      tips: [
+        'Final acceptance is coordinated with the admin team — your review informs the decision.',
+      ],
+    },
+    {
+      id: 'research',
+      title: 'Research',
+      icon: ScienceOutlinedIcon,
+      path: '/Research',
+      summary: 'Post research opportunities and see who has applied.',
+      steps: [
+        'Open Research. You will see two tabs: "My Positions" and "Research Board."',
+        'In "My Positions," click the add button to create a new listing. Fill in title, description, department, mentor, contact, and terms available, then publish.',
+        'Edit or unpublish a listing at any time from the same tab.',
+        'Switch to "Research Board" to see everything students see across the department.',
+      ],
+      tips: [
+        'Keep descriptions specific about outcomes and time commitment — you will get better-matched applicants.',
+      ],
+    },
+    {
+      id: 'courses',
+      title: 'Courses',
+      icon: BookOutlinedIcon,
+      path: '/courses',
+      summary:
+        'See the courses you are assigned for the current and past semesters.',
+      steps: [
+        'Open Courses from the sidebar.',
+        'The grid shows each course with code, title, class number, credits, meeting times, and enrollment.',
+        'Use the semester multi-select to view historical teaching assignments.',
+      ],
+      tips: ['Courses appear here after the admin uploads the semester data.'],
+    },
+    {
+      id: 'announcements',
+      title: 'Announcements',
+      icon: CampaignOutlinedIcon,
+      path: '/announcements',
+      summary: 'Read announcements and publish your own to any audience.',
+      steps: [
+        'Open Announcements and read the current inbox like any user.',
+        'Click "Add Announcement" to open the composer.',
+        'Fill in Title and Body (Markdown supported). Optionally pin the message, require acknowledgment, send via email, and set an expiration date.',
+        'Pick an audience: All users, specific Roles, specific Departments, or a custom list of users.',
+        'Schedule a future publish time or publish immediately. A preview shows the first ~140 characters.',
+      ],
+      tips: [
+        'Scheduled announcements in the past are published immediately on save.',
+        'Require acknowledgment only when you need a confirmed read — it is more friction for students.',
+      ],
+    },
+  ],
+  faqs: [
+    {
+      q: 'Why am I not seeing a student who applied to my course?',
+      a: 'Confirm the course was part of the latest admin upload for the semester and that the student submitted their application (not just drafted it).',
+    },
+    {
+      q: 'Can I delete a research listing?',
+      a: 'Yes, from the "My Positions" tab on the Research page.',
+    },
+    {
+      q: 'Who can see an announcement I post?',
+      a: 'Exactly the audience you select in the composer — All, by Role, by Department, or a specific user list.',
+    },
+  ],
+};
+
+export const ADMIN_GUIDE: HelpGuide = {
+  key: 'admin',
+  label: 'Admin',
+  tagline: 'Manage users, review applications, and run the semester.',
+  overview:
+    'Admins operate the department-wide workflow: approving faculty accounts, reviewing every TA and Supervised Teaching application, uploading semester course data, tracking faculty teaching load, and publishing announcements.',
+  quickStart: [
+    'Start each semester by uploading course data and employment actions in Courses.',
+    'Approve any pending faculty accounts in Users → Unapproved Faculty.',
+    'Review submitted applications in Applications and approve / deny in bulk or individually.',
+    'Upload teaching-load data in Faculty Stats so assignment decisions are well-informed.',
+  ],
+  sections: [
+    {
+      id: 'users',
+      title: 'Users',
+      icon: PersonOutlineOutlinedIcon,
+      path: '/users',
+      summary:
+        'The directory of every account in the system, plus the approval queue for new faculty.',
+      steps: [
+        'Open Users from the sidebar.',
+        'Tab 1 "All Users": search, filter, and paginate the full list. Inspect or update role and department.',
+        'Tab 2 "Unapproved Faculty": review each request and approve to promote the account from "unapproved" to "faculty."',
+      ],
+      tips: [
+        'Unapproved accounts have no sidebar access until you promote them.',
+      ],
+    },
+    {
+      id: 'applications',
+      title: 'Applications',
+      icon: DescriptionOutlinedIcon,
+      path: '/admin-applications',
+      summary:
+        'Review every submitted Course Assistant and Supervised Teaching application, in one grid.',
+      steps: [
+        'Open Applications from the sidebar.',
+        'Filter by status (Submitted / Approved / Denied) or search by student.',
+        'Click a row to inspect full details, download the resume, and approve or deny.',
+        'Use the bulk actions to process multiple applications at once after confirming the selection.',
+      ],
+      tips: [
+        'Approvals drive the Status page students see — keep decisions timely.',
+      ],
+    },
+    {
+      id: 'courses',
+      title: 'Courses',
+      icon: BookOutlinedIcon,
+      path: '/admincourses',
+      summary:
+        'The canonical source of semester course data. Upload, hide, and clear semesters here.',
+      steps: [
+        'Select an existing semester from the dropdown or create a new one.',
+        'Use "Upload Semester Data" to ingest the Excel course list (code, title, instructor emails, meeting times, enrollment cap).',
+        'Use "Upload Employment Actions" to attach the UFID → action mapping for the term.',
+        'Hide / Unhide a semester to control whether students can see it.',
+        '"Clear Semester Data" wipes every course for the selected semester — use with caution.',
+      ],
+      tips: [
+        'Hide the semester until uploads are complete, then unhide to make it visible.',
+        'Clearing is permanent — export or back up before running it.',
+      ],
+    },
+    {
+      id: 'faculty-stats',
+      title: 'Faculty Stats',
+      icon: BarChartOutlinedIcon,
+      path: '/faculty-stats',
+      summary:
+        'Track teaching load and research level per instructor to inform assignments.',
+      steps: [
+        'Open Faculty Stats from the sidebar.',
+        'Upload the "Teaching Load History" Excel sheet to refresh the table.',
+        "Review each instructor's load category and research level in the table.",
+        'Use "Clear Faculty Data" to start from scratch (confirmation required).',
+      ],
+    },
+    {
+      id: 'research',
+      title: 'Research',
+      icon: ScienceOutlinedIcon,
+      path: '/Research',
+      summary:
+        'Administrative view of every research listing; you can create and manage positions like faculty.',
+      steps: [
+        'Open Research to see the same two tabs faculty see.',
+        'Use "My Positions" to create or edit listings; use "Research Board" to see what students see.',
+      ],
+    },
+    {
+      id: 'announcements',
+      title: 'Announcements',
+      icon: CampaignOutlinedIcon,
+      path: '/announcements',
+      summary:
+        'Publish to any audience with full targeting, scheduling, and acknowledgment controls.',
+      steps: [
+        'Open Announcements and click "Add Announcement."',
+        'Write Title + Markdown Body; optionally pin, require acknowledgment, or send via email.',
+        'Pick an audience: All, specific Roles, Departments, or a user list.',
+        'Schedule publish and expiration dates, then save.',
+      ],
+      tips: [
+        'The audience selector supports autocomplete for named users.',
+        'Past-dated schedules publish immediately on save.',
+      ],
+    },
+  ],
+  faqs: [
+    {
+      q: 'A faculty member says their course is not showing up — why?',
+      a: 'Check the Courses page: the semester may be hidden, or that course may be missing from the most recent upload.',
+    },
+    {
+      q: 'How do I bulk-deny applications that are out of scope?',
+      a: 'Filter to the subset you want, select the rows, and use the bulk deny action. Confirm the dialog to apply.',
+    },
+    {
+      q: 'Can I recover cleared semester data?',
+      a: 'No. "Clear Semester Data" is destructive. Back up the Excel source before clearing.',
+    },
+  ],
+};
+
+export const HELP_GUIDES: Record<HelpRoleKey, HelpGuide> = {
+  student: STUDENT_GUIDE,
+  faculty: FACULTY_GUIDE,
+  admin: ADMIN_GUIDE,
+};
+
+export const HELP_ROLE_ORDER: HelpRoleKey[] = ['student', 'faculty', 'admin'];

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { FC } from 'react';
+import PageLayout from '@/components/PageLayout/PageLayout';
+import { useUserInfo } from '@/hooks/User/useGetUserInfo';
+import { getNavItems } from '@/hooks/useGetItems';
+import HelpView from './HelpView';
+
+const HelpPage: FC = () => {
+  const [user, role, loading, error] = useUserInfo();
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div>Error loading user info</div>;
+
+  return (
+    <PageLayout mainTitle="Help Center" navItems={getNavItems(role)}>
+      <HelpView role={role} />
+    </PageLayout>
+  );
+};
+
+export default HelpPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { AuthProvider } from '@/firebase/auth/auth_context';
 import { AnnouncementsProvider } from '@/contexts/AnnouncementsContext';
+import { TourProvider } from '@/contexts/TourContext';
+import TourOverlay from '@/components/Tour/TourOverlay';
 import React, { useEffect } from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
@@ -69,9 +71,12 @@ export default function RootLayout({
             >
               <AuthProvider>
                 <AnnouncementsProvider>
-                  <CssBaseline />
-                  {/*<Header ColorModeContext={ColorModeContext} />*/}
-                  {children}
+                  <TourProvider>
+                    <CssBaseline />
+                    {/*<Header ColorModeContext={ColorModeContext} />*/}
+                    {children}
+                    <TourOverlay />
+                  </TourProvider>
                 </AnnouncementsProvider>
               </AuthProvider>
             </ThemeProvider>

--- a/src/components/SideNavBar/SideNavBar.tsx
+++ b/src/components/SideNavBar/SideNavBar.tsx
@@ -31,7 +31,10 @@ export default function SideNav({ navItems }: SideNavProps) {
   };
 
   return (
-    <aside className="relative w-20 md:w-24 h-screen bg-[#6C37D8] flex flex-col justify-between pt-20 pb-4 shadow-[4px_0_16px_-6px_rgba(45,15,131,0.35)]">
+    <aside
+      data-tour="sidebar"
+      className="relative w-20 md:w-24 h-screen bg-[#6C37D8] flex flex-col justify-between pt-20 pb-4 shadow-[4px_0_16px_-6px_rgba(45,15,131,0.35)]"
+    >
       {/* top + middle items */}
       <nav className="flex flex-col gap-1.5 px-2">
         {navItems.map(({ label, to, icon: Icon }: NavbarItem) => {

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -28,6 +28,7 @@ export default function TopNav() {
     <AppBar
       position="fixed"
       elevation={0}
+      data-tour="topbar"
       className="!bg-[#2d0f83] !h-14 top-0 left-0 right-0 !z-20"
     >
       <Toolbar className="!min-h-0 !px-2 md:!px-5 flex justify-between items-center">
@@ -41,7 +42,7 @@ export default function TopNav() {
 
         <div className="!text-[#FFFFFF] flex items-center gap-3">
           {/* Notifications */}
-          <Link href="/announcements">
+          <Link href="/announcements" data-tour="notifications">
             <IconButton
               aria-label={`Announcements (${unreadCount} unread)`}
               className="!text-[#FFFFFF]"
@@ -59,7 +60,11 @@ export default function TopNav() {
           </Link>
 
           {/* User avatar + meta */}
-          <Link href="/profile" className="flex items-center gap-2">
+          <Link
+            href="/profile"
+            data-tour="profile"
+            className="flex items-center gap-2"
+          >
             {/* Circle avatar placeholder (letter) */}
             <div className="w-9 h-9 rounded-full bg-opacity-20 flex items-center justify-center">
               <AccountCircleTwoToneIcon className="text-white" />

--- a/src/components/Tour/TourOverlay.tsx
+++ b/src/components/Tour/TourOverlay.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
+import { useTour } from '@/contexts/TourContext';
+
+type Rect = { top: number; left: number; width: number; height: number };
+
+const PAD = 8;
+const GAP = 16;
+const TOOLTIP_W = 340;
+const TOOLTIP_H = 220; // approximate; used only for placement clamping
+
+const TourOverlay: React.FC = () => {
+  const { isRunning, stepIndex, steps, next, prev, stop } = useTour();
+  const [rect, setRect] = useState<Rect | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  const step = steps[stepIndex];
+
+  useEffect(() => {
+    if (!isRunning || !step) return;
+
+    if (!step.target) {
+      setRect(null);
+      return;
+    }
+
+    let poll: ReturnType<typeof setInterval> | null = null;
+    let raf = 0;
+
+    const update = (): boolean => {
+      const el = document.querySelector(step.target!) as HTMLElement | null;
+      if (!el) {
+        setRect(null);
+        return false;
+      }
+      const r = el.getBoundingClientRect();
+      setRect({
+        top: r.top - PAD,
+        left: r.left - PAD,
+        width: r.width + PAD * 2,
+        height: r.height + PAD * 2,
+      });
+      el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      return true;
+    };
+
+    if (!update()) {
+      const started = Date.now();
+      poll = setInterval(() => {
+        if (update() || Date.now() - started > 3000) {
+          if (poll) clearInterval(poll);
+        }
+      }, 100);
+    }
+
+    const onViewport = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => update());
+    };
+    window.addEventListener('resize', onViewport);
+    window.addEventListener('scroll', onViewport, true);
+
+    return () => {
+      window.removeEventListener('resize', onViewport);
+      window.removeEventListener('scroll', onViewport, true);
+      if (poll) clearInterval(poll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [isRunning, step]);
+
+  useEffect(() => {
+    if (!isRunning) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') stop();
+      else if (e.key === 'ArrowRight' || e.key === 'Enter') next();
+      else if (e.key === 'ArrowLeft') prev();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isRunning, next, prev, stop]);
+
+  if (!mounted || !isRunning || !step) return null;
+
+  const isLast = stepIndex === steps.length - 1;
+  const isFirst = stepIndex === 0;
+
+  const tooltipStyle = computeTooltipPosition(rect, step.placement);
+
+  return createPortal(
+    <div aria-live="polite" role="dialog" aria-modal="true">
+      {/* Full-page blocker (transparent when a target is spotlit; dimmed for modal steps). */}
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          zIndex: 9998,
+          background: rect ? 'transparent' : 'rgba(10, 5, 30, 0.55)',
+          pointerEvents: 'auto',
+        }}
+      />
+
+      {/* Spotlight — outer box-shadow dims the rest of the page. */}
+      {rect && (
+        <div
+          aria-hidden
+          style={{
+            position: 'fixed',
+            top: rect.top,
+            left: rect.left,
+            width: rect.width,
+            height: rect.height,
+            borderRadius: 12,
+            boxShadow: '0 0 0 9999px rgba(10, 5, 30, 0.58)',
+            outline: '2px solid rgba(255, 255, 255, 0.95)',
+            outlineOffset: 2,
+            zIndex: 9999,
+            pointerEvents: 'none',
+            transition:
+              'top 0.28s ease, left 0.28s ease, width 0.28s ease, height 0.28s ease',
+          }}
+        />
+      )}
+
+      {/* Tooltip */}
+      <div
+        style={{
+          position: 'fixed',
+          zIndex: 10001,
+          width: TOOLTIP_W,
+          ...tooltipStyle,
+        }}
+        className="rounded-2xl bg-white border border-[#E7E1F7] shadow-[0_24px_60px_-24px_rgba(45,15,131,0.55)] p-5"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <AutoAwesomeOutlinedIcon sx={{ color: '#5A41D8', fontSize: 18 }} />
+            <span className="text-[11px] font-semibold tracking-wider text-[#5A41D8] uppercase">
+              Walkthrough · {stepIndex + 1} / {steps.length}
+            </span>
+          </div>
+          <button
+            onClick={stop}
+            aria-label="Close walkthrough"
+            className="text-[#6B5AA8] hover:text-[#1E1442] -m-1 p-1 rounded-md hover:bg-[#F4F1FC] transition-colors"
+          >
+            <CloseRoundedIcon fontSize="small" />
+          </button>
+        </div>
+
+        <h4 className="text-[17px] font-semibold text-[#1E1442] mt-2">
+          {step.title}
+        </h4>
+        <p className="text-sm text-[#4A3F6B] mt-1.5 leading-relaxed">
+          {step.body}
+        </p>
+
+        <div className="flex items-center justify-between mt-5">
+          <div className="flex gap-1.5 items-center">
+            {steps.map((_, i) => (
+              <span
+                key={i}
+                aria-hidden
+                className={`block h-1.5 rounded-full transition-all duration-200 ${
+                  i === stepIndex
+                    ? 'bg-[#5A41D8] w-6'
+                    : i < stepIndex
+                    ? 'bg-[#B7A6EE] w-1.5'
+                    : 'bg-[#E7E1F7] w-1.5'
+                }`}
+              />
+            ))}
+          </div>
+          <div className="flex gap-2">
+            {!isFirst && (
+              <button
+                onClick={prev}
+                className="text-sm font-medium text-[#5A41D8] px-3 py-1.5 rounded-md hover:bg-[#F4F1FC] transition-colors"
+              >
+                Back
+              </button>
+            )}
+            <button
+              onClick={next}
+              className="text-sm font-semibold text-white bg-[#5A41D8] hover:bg-[#4834C8] px-4 py-1.5 rounded-md shadow-[0_4px_12px_rgba(90,65,216,0.28)] transition-colors"
+            >
+              {isLast ? 'Finish' : 'Next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+function computeTooltipPosition(
+  rect: Rect | null,
+  placement: 'right' | 'bottom' | 'left' | 'top' | 'center' | undefined
+): React.CSSProperties {
+  if (!rect) {
+    return { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' };
+  }
+  const vw = typeof window !== 'undefined' ? window.innerWidth : 1200;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 800;
+  const p = placement ?? 'right';
+
+  let top = rect.top;
+  let left = rect.left;
+
+  if (p === 'right') {
+    top = rect.top;
+    left = rect.left + rect.width + GAP;
+  } else if (p === 'left') {
+    top = rect.top;
+    left = rect.left - TOOLTIP_W - GAP;
+  } else if (p === 'bottom') {
+    top = rect.top + rect.height + GAP;
+    left = rect.left;
+  } else if (p === 'top') {
+    top = rect.top - TOOLTIP_H - GAP;
+    left = rect.left;
+  }
+
+  // Clamp inside the viewport with a small margin.
+  const margin = 12;
+  left = Math.max(margin, Math.min(left, vw - TOOLTIP_W - margin));
+  top = Math.max(margin, Math.min(top, vh - TOOLTIP_H - margin));
+
+  return { top, left };
+}
+
+export default TourOverlay;

--- a/src/components/Tour/tourSteps.ts
+++ b/src/components/Tour/tourSteps.ts
@@ -1,0 +1,220 @@
+import { HelpRoleKey } from '@/app/help/content';
+
+export type Placement = 'right' | 'bottom' | 'left' | 'top' | 'center';
+
+export type TourStep = {
+  id: string;
+  title: string;
+  body: string;
+  /** CSS selector for the element to spotlight. Omit for a centered modal step. */
+  target?: string;
+  placement?: Placement;
+};
+
+const TOPBAR_STEPS: TourStep[] = [
+  {
+    id: 'topbar',
+    target: '[data-tour="topbar"]',
+    placement: 'bottom',
+    title: 'Your top bar',
+    body: 'Your profile, the department logo (which links back to the Dashboard), and the announcements bell live here on every page.',
+  },
+  {
+    id: 'notifications',
+    target: '[data-tour="notifications"]',
+    placement: 'bottom',
+    title: 'Announcements inbox',
+    body: 'The red badge shows your unread count. Click the bell to jump straight to announcements from anywhere.',
+  },
+  {
+    id: 'profile',
+    target: '[data-tour="profile"]',
+    placement: 'bottom',
+    title: 'Your profile',
+    body: 'Your name and current role are shown here. Click to open your profile details.',
+  },
+];
+
+const END_STEP = (closing: string): TourStep => ({
+  id: 'end',
+  title: "You're all set",
+  body: closing,
+});
+
+export const TOUR_STEPS: Record<HelpRoleKey, TourStep[]> = {
+  student: [
+    {
+      id: 'welcome',
+      title: 'Welcome to CourseConnect',
+      body: 'Take a 60-second tour of the tools available to you as a student. You can skip any time with the button in the top-right of this card.',
+    },
+    {
+      id: 'sidebar',
+      target: '[data-tour="sidebar"]',
+      placement: 'right',
+      title: 'Your sidebar',
+      body: 'Every feature lives on this sidebar. The icons stay visible on every page so you always know where to go next.',
+    },
+    {
+      id: 'nav-applications',
+      target: '[data-testid="nav-Applications"]',
+      placement: 'right',
+      title: 'Applications',
+      body: 'Submit a Course Assistant (undergrad / MS TA) or Supervised Teaching (PhD EEL 6940) application here.',
+    },
+    {
+      id: 'nav-research',
+      target: '[data-testid="nav-Research"]',
+      placement: 'right',
+      title: 'Research',
+      body: 'Browse faculty-posted research positions and submit interest to the ones that match your goals.',
+    },
+    {
+      id: 'nav-status',
+      target: '[data-testid="nav-Status"]',
+      placement: 'right',
+      title: 'Status',
+      body: 'A live view of every application you have submitted, with the current decision for each one.',
+    },
+    {
+      id: 'nav-announcements',
+      target: '[data-testid="nav-Announcements"]',
+      placement: 'right',
+      title: 'Announcements',
+      body: 'Department-wide updates. Some may require you to acknowledge them before they are dismissed.',
+    },
+    {
+      id: 'nav-help',
+      target: '[data-testid="nav-Help"]',
+      placement: 'right',
+      title: 'Help Center',
+      body: "You're here. Come back any time to re-run this tour or read the step-by-step guides.",
+    },
+    ...TOPBAR_STEPS,
+    END_STEP(
+      'Start with Applications to submit your first application, or Research to find a position that fits.'
+    ),
+  ],
+
+  faculty: [
+    {
+      id: 'welcome',
+      title: 'Welcome, faculty',
+      body: 'A quick tour of the tools you use to review applicants, manage your courses, and post research opportunities.',
+    },
+    {
+      id: 'sidebar',
+      target: '[data-tour="sidebar"]',
+      placement: 'right',
+      title: 'Your sidebar',
+      body: 'All of your tools are one click away from this bar, on every page.',
+    },
+    {
+      id: 'nav-applications',
+      target: '[data-testid="nav-Applications"]',
+      placement: 'right',
+      title: 'Applicants',
+      body: 'Review the students who applied to courses you teach — resumes, qualifications, and course preferences in one view.',
+    },
+    {
+      id: 'nav-research',
+      target: '[data-testid="nav-Research"]',
+      placement: 'right',
+      title: 'Research',
+      body: 'Post and manage your own research positions under "My Positions," and browse the full board students see.',
+    },
+    {
+      id: 'nav-courses',
+      target: '[data-testid="nav-Courses"]',
+      placement: 'right',
+      title: 'Courses',
+      body: 'Your current and past teaching assignments, with enrollment, meeting times, and class numbers.',
+    },
+    {
+      id: 'nav-announcements',
+      target: '[data-testid="nav-Announcements"]',
+      placement: 'right',
+      title: 'Announcements',
+      body: 'Read the inbox and publish your own announcements. You can target by role, department, or specific users, and require acknowledgment.',
+    },
+    {
+      id: 'nav-help',
+      target: '[data-testid="nav-Help"]',
+      placement: 'right',
+      title: 'Help Center',
+      body: 'Return here any time for detailed how-tos and to re-run this walkthrough.',
+    },
+    ...TOPBAR_STEPS,
+    END_STEP(
+      'Open Applications to review incoming students, or Research to post your next opportunity.'
+    ),
+  ],
+
+  admin: [
+    {
+      id: 'welcome',
+      title: 'Welcome, admin',
+      body: 'This tour covers the full toolkit you use to run the department semester end-to-end.',
+    },
+    {
+      id: 'sidebar',
+      target: '[data-tour="sidebar"]',
+      placement: 'right',
+      title: 'Your sidebar',
+      body: 'All admin tools live here. Order is optimized for the way the semester flows.',
+    },
+    {
+      id: 'nav-users',
+      target: '[data-testid="nav-Users"]',
+      placement: 'right',
+      title: 'Users',
+      body: 'The directory of every account. Use the "Unapproved Faculty" tab to promote new faculty accounts.',
+    },
+    {
+      id: 'nav-applications',
+      target: '[data-testid="nav-Applications"]',
+      placement: 'right',
+      title: 'Applications',
+      body: 'Review, approve, or deny every submitted TA and Supervised Teaching application — individually or in bulk.',
+    },
+    {
+      id: 'nav-courses',
+      target: '[data-testid="nav-Courses"]',
+      placement: 'right',
+      title: 'Courses',
+      body: 'Upload semester data and employment actions, hide semesters until ready, or clear a semester when retiring it.',
+    },
+    {
+      id: 'nav-faculty-stats',
+      target: '[data-testid="nav-Faculty Stats"]',
+      placement: 'right',
+      title: 'Faculty Stats',
+      body: 'Teaching load and research level per instructor, driven by an uploaded Excel sheet. Informs assignment decisions.',
+    },
+    {
+      id: 'nav-research',
+      target: '[data-testid="nav-Research"]',
+      placement: 'right',
+      title: 'Research',
+      body: 'Post and manage research listings with the same tools faculty use.',
+    },
+    {
+      id: 'nav-announcements',
+      target: '[data-testid="nav-Announcements"]',
+      placement: 'right',
+      title: 'Announcements',
+      body: 'Publish to any audience: everyone, by role, by department, or a specific user list. Schedule, pin, or require acknowledgment.',
+    },
+    {
+      id: 'nav-help',
+      target: '[data-testid="nav-Help"]',
+      placement: 'right',
+      title: 'Help Center',
+      body: 'Role-aware guides plus this walkthrough are always one click away.',
+    },
+    ...TOPBAR_STEPS,
+    END_STEP(
+      'A natural starting point: upload course data in Courses, then approve any pending faculty in Users.'
+    ),
+  ],
+};

--- a/src/contexts/TourContext.tsx
+++ b/src/contexts/TourContext.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { HelpRoleKey } from '@/app/help/content';
+import { TOUR_STEPS, TourStep } from '@/components/Tour/tourSteps';
+
+type TourContextValue = {
+  isRunning: boolean;
+  stepIndex: number;
+  steps: TourStep[];
+  start: (roleKey: HelpRoleKey) => void;
+  stop: () => void;
+  next: () => void;
+  prev: () => void;
+};
+
+const TourContext = createContext<TourContextValue | null>(null);
+
+export const TourProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [isRunning, setIsRunning] = useState(false);
+  const [steps, setSteps] = useState<TourStep[]>([]);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const start = useCallback((roleKey: HelpRoleKey) => {
+    setSteps(TOUR_STEPS[roleKey]);
+    setStepIndex(0);
+    setIsRunning(true);
+  }, []);
+
+  const stop = useCallback(() => {
+    setIsRunning(false);
+    setStepIndex(0);
+  }, []);
+
+  const next = useCallback(() => {
+    setStepIndex((i) => {
+      if (i >= steps.length - 1) {
+        setIsRunning(false);
+        return 0;
+      }
+      return i + 1;
+    });
+  }, [steps.length]);
+
+  const prev = useCallback(() => {
+    setStepIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  const value = useMemo(
+    () => ({ isRunning, stepIndex, steps, start, stop, next, prev }),
+    [isRunning, stepIndex, steps, start, stop, next, prev]
+  );
+
+  return <TourContext.Provider value={value}>{children}</TourContext.Provider>;
+};
+
+export const useTour = (): TourContextValue => {
+  const ctx = useContext(TourContext);
+  if (!ctx) throw new Error('useTour must be used within a TourProvider');
+  return ctx;
+};

--- a/src/hooks/useGetItems.ts
+++ b/src/hooks/useGetItems.ts
@@ -7,6 +7,7 @@ import BarChartOutlinedIcon from '@mui/icons-material/BarChartOutlined';
 import CampaignOutlinedIcon from '@mui/icons-material/CampaignOutlined';
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
 import { NavbarItem } from '@/types/navigation';
 import { SemesterName } from './useSemesterOptions';
 import { useMemo } from 'react';
@@ -30,6 +31,7 @@ export const getNavItems = (userRole: Role): NavbarItem[] => {
           to: '/announcements',
           icon: CampaignOutlinedIcon,
         },
+        { label: 'Help', to: '/help', icon: HelpOutlineOutlinedIcon },
       ];
 
     /* ────────────────────────────────── Faculty ────────────────────────────────── */
@@ -47,6 +49,7 @@ export const getNavItems = (userRole: Role): NavbarItem[] => {
           to: '/announcements',
           icon: CampaignOutlinedIcon,
         },
+        { label: 'Help', to: '/help', icon: HelpOutlineOutlinedIcon },
       ];
 
     /* ─────────────────────────────────── Admin ─────────────────────────────────── */
@@ -75,6 +78,7 @@ export const getNavItems = (userRole: Role): NavbarItem[] => {
           to: '/announcements',
           icon: CampaignOutlinedIcon,
         },
+        { label: 'Help', to: '/help', icon: HelpOutlineOutlinedIcon },
       ];
 
     /* ───────────────────────────── Roles with no menu ──────────────────────────── */


### PR DESCRIPTION
Adds /help route with tabbed Student/Faculty/Admin guides (overview, quick start, feature how-tos, FAQ) and an interactive spotlight tour triggered from a prominent CTA. Tour highlights sidebar items and top-bar controls per role with keyboard navigation (Esc / arrows).