### PR TITLE
feat(help): add Slack-forwarded bug report button and role-gated tabs

### DIFF
--- a/src/app/api/v1/bug-report/route.ts
+++ b/src/app/api/v1/bug-report/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from 'next/server';
+
+type BugReportPayload = {
+  summary?: string;
+  description?: string;
+  severity?: 'low' | 'medium' | 'high';
+  pageUrl?: string;
+  userAgent?: string;
+  user?: {
+    uid?: string;
+    email?: string;
+    displayName?: string;
+    role?: string;
+  };
+};
+
+const SEVERITY_EMOJI: Record<string, string> = {
+  low: ':large_blue_circle:',
+  medium: ':large_yellow_circle:',
+  high: ':red_circle:',
+};
+
+const truncate = (value: string, max = 2500) =>
+  value.length > max ? `${value.slice(0, max)}…` : value;
+
+export async function POST(request: Request) {
+  const webhookUrl = process.env.SLACK_BUG_WEBHOOK_URL;
+  if (!webhookUrl) {
+    return NextResponse.json(
+      { error: 'Slack webhook is not configured on the server.' },
+      { status: 500 }
+    );
+  }
+
+  let body: BugReportPayload;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid JSON payload.' },
+      { status: 400 }
+    );
+  }
+
+  const summary = (body.summary || '').trim();
+  const description = (body.description || '').trim();
+
+  if (!summary || !description) {
+    return NextResponse.json(
+      { error: 'Summary and description are required.' },
+      { status: 400 }
+    );
+  }
+
+  const severity = body.severity ?? 'medium';
+  const severityEmoji = SEVERITY_EMOJI[severity] ?? SEVERITY_EMOJI.medium;
+
+  const who =
+    body.user?.displayName || body.user?.email || body.user?.uid || 'unknown';
+  const role = body.user?.role || 'unknown';
+
+  const slackPayload = {
+    text: `${severityEmoji} *CourseConnect bug report* — ${truncate(
+      summary,
+      140
+    )}`,
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: `${severityEmoji} Bug report: ${truncate(summary, 140)}`,
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*Reported by:*\n${who}` },
+          { type: 'mrkdwn', text: `*Role:*\n${role}` },
+          { type: 'mrkdwn', text: `*Severity:*\n${severity}` },
+          {
+            type: 'mrkdwn',
+            text: `*Email:*\n${body.user?.email ?? 'n/a'}`,
+          },
+        ],
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Description:*\n${truncate(description)}`,
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `Page: ${body.pageUrl ?? 'n/a'} • UA: ${truncate(
+              body.userAgent ?? 'n/a',
+              200
+            )}`,
+          },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(slackPayload),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      console.error('Slack webhook failed:', res.status, text);
+      return NextResponse.json(
+        { error: 'Slack rejected the report.' },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('Bug report forwarding failed:', err);
+    return NextResponse.json(
+      { error: 'Failed to deliver bug report.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/help/HelpView.tsx
+++ b/src/app/help/HelpView.tsx
@@ -2,7 +2,20 @@
 
 import React, { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Box, Tabs, Tab } from '@mui/material';
+import {
+  Box,
+  Tabs,
+  Tab,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  MenuItem,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
 import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
 import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded';
 import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined';
@@ -10,8 +23,10 @@ import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
 import RocketLaunchOutlinedIcon from '@mui/icons-material/RocketLaunchOutlined';
 import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
 import AutoAwesomeOutlinedIcon from '@mui/icons-material/AutoAwesomeOutlined';
+import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import { Role } from '@/types/User';
 import { useTour } from '@/contexts/TourContext';
+import { useAuth } from '@/firebase/auth/auth_context';
 import {
   HELP_GUIDES,
   HELP_ROLE_ORDER,
@@ -31,18 +46,31 @@ const roleToKey = (role: Role | string | undefined): HelpRoleKey => {
   }
 };
 
+const visibleRolesFor = (key: HelpRoleKey): HelpRoleKey[] => {
+  switch (key) {
+    case 'admin':
+      return HELP_ROLE_ORDER;
+    case 'faculty':
+      return ['student', 'faculty'];
+    default:
+      return ['student'];
+  }
+};
+
 type HelpViewProps = {
   role: Role | string | undefined;
 };
 
 const HelpView: React.FC<HelpViewProps> = ({ role }) => {
   const defaultKey = useMemo(() => roleToKey(role), [role]);
+  const visibleRoles = useMemo(() => visibleRolesFor(defaultKey), [defaultKey]);
   const [activeKey, setActiveKey] = useState<HelpRoleKey>(defaultKey);
   const [openSection, setOpenSection] = useState<string | null>(null);
+  const [bugOpen, setBugOpen] = useState(false);
   const { start } = useTour();
 
   const guide: HelpGuide = HELP_GUIDES[activeKey];
-  const activeIndex = HELP_ROLE_ORDER.indexOf(activeKey);
+  const activeIndex = Math.max(0, visibleRoles.indexOf(activeKey));
 
   return (
     <div className="pb-16">
@@ -60,9 +88,9 @@ const HelpView: React.FC<HelpViewProps> = ({ role }) => {
               Get up to speed with CourseConnect
             </h2>
             <p className="mt-2 text-sm md:text-[15px] text-[#4A3F6B] leading-relaxed max-w-3xl">
-              Pick your role below to see step-by-step instructions for every
-              feature you use. Your own role is selected by default — switch
-              tabs any time to see what the other roles experience.
+              {visibleRoles.length > 1
+                ? 'Pick your role below to see step-by-step instructions for every feature you use. Your own role is selected by default — switch tabs any time to see what the other roles experience.'
+                : 'Step-by-step instructions for every feature you use in CourseConnect.'}
             </p>
           </div>
         </div>
@@ -92,7 +120,7 @@ const HelpView: React.FC<HelpViewProps> = ({ role }) => {
         </div>
         <button
           type="button"
-          onClick={() => start(activeKey)}
+          onClick={() => start(defaultKey)}
           className="shrink-0 inline-flex items-center justify-center gap-2 bg-white text-[#2d0f83] hover:bg-[#F4F1FC] font-semibold px-5 py-2.5 rounded-full shadow-[0_6px_20px_rgba(0,0,0,0.18)] transition-colors"
         >
           <PlayArrowRoundedIcon sx={{ fontSize: 20 }} />
@@ -101,52 +129,54 @@ const HelpView: React.FC<HelpViewProps> = ({ role }) => {
       </div>
 
       {/* Role tabs */}
-      <Box
-        sx={{
-          display: 'inline-flex',
-          p: 0.5,
-          mb: 4,
-          backgroundColor: '#F4F1FC',
-          borderRadius: '999px',
-        }}
-      >
-        <Tabs
-          value={activeIndex}
-          onChange={(_, v) => setActiveKey(HELP_ROLE_ORDER[v])}
-          TabIndicatorProps={{ sx: { display: 'none' } }}
+      {visibleRoles.length > 1 && (
+        <Box
           sx={{
-            minHeight: 'auto',
-            '& .MuiTabs-flexContainer': { gap: 0.5 },
-            '& .MuiTab-root': {
-              textTransform: 'none',
-              fontWeight: 600,
-              fontSize: '0.88rem',
-              minHeight: 36,
-              py: 0.75,
-              px: 2.5,
-              borderRadius: '999px',
-              color: '#6B5AA8',
-              transition: 'all 0.15s ease',
-            },
-            '& .Mui-selected': {
-              color: '#fff !important',
-              backgroundColor: '#5A41D8',
-              boxShadow: '0 4px 12px rgba(90, 65, 216, 0.24)',
-            },
+            display: 'inline-flex',
+            p: 0.5,
+            mb: 4,
+            backgroundColor: '#F4F1FC',
+            borderRadius: '999px',
           }}
         >
-          {HELP_ROLE_ORDER.map((key) => (
-            <Tab
-              key={key}
-              label={
-                key === defaultKey
-                  ? `${HELP_GUIDES[key].label} (you)`
-                  : HELP_GUIDES[key].label
-              }
-            />
-          ))}
-        </Tabs>
-      </Box>
+          <Tabs
+            value={activeIndex}
+            onChange={(_, v) => setActiveKey(visibleRoles[v])}
+            TabIndicatorProps={{ sx: { display: 'none' } }}
+            sx={{
+              minHeight: 'auto',
+              '& .MuiTabs-flexContainer': { gap: 0.5 },
+              '& .MuiTab-root': {
+                textTransform: 'none',
+                fontWeight: 600,
+                fontSize: '0.88rem',
+                minHeight: 36,
+                py: 0.75,
+                px: 2.5,
+                borderRadius: '999px',
+                color: '#6B5AA8',
+                transition: 'all 0.15s ease',
+              },
+              '& .Mui-selected': {
+                color: '#fff !important',
+                backgroundColor: '#5A41D8',
+                boxShadow: '0 4px 12px rgba(90, 65, 216, 0.24)',
+              },
+            }}
+          >
+            {visibleRoles.map((key) => (
+              <Tab
+                key={key}
+                label={
+                  key === defaultKey
+                    ? `${HELP_GUIDES[key].label} (you)`
+                    : HELP_GUIDES[key].label
+                }
+              />
+            ))}
+          </Tabs>
+        </Box>
+      )}
 
       {/* Overview */}
       <section className="mb-10">
@@ -213,7 +243,7 @@ const HelpView: React.FC<HelpViewProps> = ({ role }) => {
       </section>
 
       {/* FAQ */}
-      <section>
+      <section className="mb-12">
         <div className="flex items-center gap-2 mb-4">
           <span className="inline-block w-1 h-5 rounded-full bg-[#5A41D8]" />
           <h3 className="text-lg font-semibold text-[#1E1442]">
@@ -234,6 +264,42 @@ const HelpView: React.FC<HelpViewProps> = ({ role }) => {
           ))}
         </div>
       </section>
+
+      {/* Bug report CTA */}
+      <section>
+        <div className="rounded-2xl border border-[#F3D9D5] bg-gradient-to-br from-[#FFF5F3] to-white p-6 md:p-7 flex flex-col md:flex-row md:items-center gap-5">
+          <div className="shrink-0 w-12 h-12 rounded-xl bg-[#E5484D] text-white flex items-center justify-center">
+            <BugReportOutlinedIcon sx={{ fontSize: 26 }} />
+          </div>
+          <div className="flex-1">
+            <p className="text-[11px] font-semibold tracking-[0.18em] uppercase text-[#B5322D]">
+              Something wrong?
+            </p>
+            <h3 className="text-[19px] md:text-[21px] font-semibold text-[#1E1442] mt-0.5">
+              Report a bug or send feedback
+            </h3>
+            <p className="text-sm text-[#4A3F6B] mt-1.5 leading-relaxed max-w-2xl">
+              Run into a glitch, confusing flow, or something broken? Send the
+              details straight to the CourseConnect team on Slack — we&apos;ll
+              jump on it.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setBugOpen(true)}
+            className="shrink-0 inline-flex items-center justify-center gap-2 bg-[#E5484D] text-white hover:bg-[#C43A3E] font-semibold px-5 py-2.5 rounded-full shadow-[0_6px_20px_rgba(229,72,77,0.25)] transition-colors"
+          >
+            <BugReportOutlinedIcon sx={{ fontSize: 20 }} />
+            Report a bug
+          </button>
+        </div>
+      </section>
+
+      <BugReportDialog
+        open={bugOpen}
+        onClose={() => setBugOpen(false)}
+        role={role}
+      />
     </div>
   );
 };
@@ -335,6 +401,172 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
         </div>
       )}
     </div>
+  );
+};
+
+type BugReportDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  role: Role | string | undefined;
+};
+
+const BugReportDialog: React.FC<BugReportDialogProps> = ({
+  open,
+  onClose,
+  role,
+}) => {
+  const { user } = useAuth();
+  const [summary, setSummary] = useState('');
+  const [description, setDescription] = useState('');
+  const [severity, setSeverity] = useState<'low' | 'medium' | 'high'>('medium');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const reset = () => {
+    setSummary('');
+    setDescription('');
+    setSeverity('medium');
+    setError(null);
+    setSuccess(false);
+  };
+
+  const handleClose = () => {
+    if (submitting) return;
+    onClose();
+    setTimeout(reset, 200);
+  };
+
+  const handleSubmit = async () => {
+    if (!summary.trim() || !description.trim()) {
+      setError('Please add a short summary and a description.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/v1/bug-report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          summary: summary.trim(),
+          description: description.trim(),
+          severity,
+          pageUrl:
+            typeof window !== 'undefined' ? window.location.href : undefined,
+          userAgent:
+            typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+          user: {
+            uid: user?.uid,
+            email: user?.email ?? undefined,
+            displayName: user?.displayName ?? undefined,
+            role: typeof role === 'string' ? role : undefined,
+          },
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Could not send the bug report.');
+      }
+      setSuccess(true);
+      setTimeout(() => {
+        onClose();
+        reset();
+      }, 1200);
+    } catch (e: any) {
+      setError(e.message || 'Could not send the bug report.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={{ fontWeight: 600, color: '#1E1442' }}>
+        Report a bug
+      </DialogTitle>
+      <DialogContent dividers>
+        {success ? (
+          <Alert severity="success">
+            Thanks! Your report was sent to the CourseConnect team.
+          </Alert>
+        ) : (
+          <>
+            {error && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {error}
+              </Alert>
+            )}
+            <TextField
+              label="Short summary"
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+              fullWidth
+              required
+              inputProps={{ maxLength: 140 }}
+              helperText={`${summary.length}/140`}
+              sx={{ mb: 2 }}
+              disabled={submitting}
+            />
+            <TextField
+              label="What happened? Include steps to reproduce if you can."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              fullWidth
+              required
+              multiline
+              minRows={5}
+              inputProps={{ maxLength: 4000 }}
+              sx={{ mb: 2 }}
+              disabled={submitting}
+            />
+            <TextField
+              label="Severity"
+              value={severity}
+              onChange={(e) =>
+                setSeverity(e.target.value as 'low' | 'medium' | 'high')
+              }
+              select
+              fullWidth
+              disabled={submitting}
+            >
+              <MenuItem value="low">Low — minor annoyance</MenuItem>
+              <MenuItem value="medium">Medium — noticeable issue</MenuItem>
+              <MenuItem value="high">High — blocker / broken</MenuItem>
+            </TextField>
+            <p className="text-xs text-[#6B5AA8] mt-3">
+              We&apos;ll include your email, role, and the page URL so the team
+              can follow up.
+            </p>
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={submitting}>
+          {success ? 'Close' : 'Cancel'}
+        </Button>
+        {!success && (
+          <Button
+            onClick={handleSubmit}
+            disabled={submitting}
+            variant="contained"
+            sx={{
+              backgroundColor: '#5A41D8',
+              '&:hover': { backgroundColor: '#2d0f83' },
+            }}
+            startIcon={
+              submitting ? (
+                <CircularProgress size={16} color="inherit" />
+              ) : (
+                <BugReportOutlinedIcon />
+              )
+            }
+          >
+            {submitting ? 'Sending…' : 'Send report'}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
   );
 };
 


### PR DESCRIPTION
Adds a "Report a bug" CTA in the Help Center that opens a dialog with summary, description, and severity. Submissions POST to a new /api/v1/bug-report route that forwards a formatted Block Kit message to SLACK_BUG_WEBHOOK_URL with reporter email, role, page URL, and UA.

Also gates role tabs by the viewer's own role (students see Student only; faculty see Student + Faculty; admins see all) and locks the interactive walkthrough to the user's actual role instead of the currently selected tab.