### PR TITLE
feat(forms): modernize auth cards and student application forms

### DIFF
--- a/src/app/applications/courseAssistant/page.tsx
+++ b/src/app/applications/courseAssistant/page.tsx
@@ -31,6 +31,24 @@ import {
   CourseOption,
 } from '@/hooks/useSemesterOptions';
 import { callFunction } from '@/firebase/functions/callFunction';
+import { modernInputSx } from '@/components/FormStyles';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^[\d()+\-\s]{7,20}$/;
+const UFID_RE = /^\d{8}$/;
+
+type FieldErrors = Partial<
+  Record<
+    | 'firstName'
+    | 'lastName'
+    | 'email'
+    | 'ufid'
+    | 'phone'
+    | 'resumeLink'
+    | 'qualifications',
+    string
+  >
+>;
 
 export default function Application() {
   const router = useRouter();
@@ -49,6 +67,15 @@ export default function Application() {
 
   const [selectedCourses, setSelectedCourses] = React.useState<string[]>([]);
   const [names, setNames] = useState<{ raw: string; semester: string }[]>([]);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+
+  const clearFieldError = (key: keyof FieldErrors) =>
+    setFieldErrors((prev) => {
+      if (!prev[key]) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
 
   const handleAdditionalPromptChange = (newValue: string) => {
     setAdditionalPromptValue(newValue);
@@ -191,74 +218,53 @@ export default function Application() {
       resume_link: formData.get('resumeLink') as string,
     };
 
-    if (!applicationData.email.includes('ufl.edu')) {
-      toast.error('Please enter a valid ufl email!');
+    const nextErrors: FieldErrors = {};
+    if (!applicationData.firstname.trim())
+      nextErrors.firstName = 'First name is required.';
+    if (!applicationData.lastname.trim())
+      nextErrors.lastName = 'Last name is required.';
+    if (!applicationData.email.trim()) nextErrors.email = 'Email is required.';
+    else if (!EMAIL_RE.test(applicationData.email))
+      nextErrors.email = 'Enter a valid email address.';
+    else if (!applicationData.email.toLowerCase().endsWith('ufl.edu'))
+      nextErrors.email = 'Must be a ufl.edu email.';
+    if (!applicationData.ufid.trim()) nextErrors.ufid = 'UFID is required.';
+    else if (!UFID_RE.test(applicationData.ufid))
+      nextErrors.ufid = 'UFID must be 8 digits.';
+    if (!applicationData.phonenumber.trim())
+      nextErrors.phone = 'Phone number is required.';
+    else if (!PHONE_RE.test(applicationData.phonenumber))
+      nextErrors.phone = 'Enter a valid phone number.';
+    if (!applicationData.resume_link?.trim())
+      nextErrors.resumeLink = 'Resume link is required.';
+    else if (!/^https?:\/\//.test(applicationData.resume_link))
+      nextErrors.resumeLink = 'Must be a full URL (starts with http/https).';
+    if (!applicationData.qualifications?.trim())
+      nextErrors.qualifications = 'Please describe your qualifications.';
+
+    const dropdownMsg: string[] = [];
+    if (!applicationData.degree) dropdownMsg.push('degree');
+    if (!applicationData.department) dropdownMsg.push('department');
+    if (!applicationData.semesterstatus) dropdownMsg.push('semester status');
+    if (!applicationData.position) dropdownMsg.push('position');
+    if (applicationData.available_hours.length === 0)
+      dropdownMsg.push('available hours');
+    if (coursesArray.length === 0) dropdownMsg.push('at least one course');
+
+    if (Object.keys(nextErrors).length > 0 || dropdownMsg.length > 0) {
+      setFieldErrors(nextErrors);
+      if (Object.keys(nextErrors).length > 0) {
+        toast.error('Please fix the highlighted fields.');
+      }
+      if (dropdownMsg.length > 0) {
+        toast.error(`Please select: ${dropdownMsg.join(', ')}.`);
+      }
       setLoading(false);
       return;
-    } else if (applicationData.firstname === '') {
-      toast.error('Please enter a valid first name!');
-      setLoading(false);
-      return;
-    } else if (applicationData.lastname === '') {
-      toast.error('Please enter a valid last name!');
-      setLoading(false);
-      return;
-    } else if (applicationData.ufid === '') {
-      toast.error('Please enter a valid ufid!');
-      setLoading(false);
-      return;
-    } else if (applicationData.phonenumber === '') {
-      toast.error('Please enter a valid phone number!');
-      setLoading(false);
-      return;
-    } else if (
-      applicationData.degree === null ||
-      applicationData.degree === ''
-    ) {
-      toast.error('Please select a degree!');
-      setLoading(false);
-      return;
-    } else if (
-      applicationData.department === null ||
-      applicationData.department === ''
-    ) {
-      toast.error('Please select a department!');
-      setLoading(false);
-      return;
-    } else if (
-      applicationData.semesterstatus === null ||
-      applicationData.semesterstatus === ''
-    ) {
-      toast.error('Please select a semester status!');
-      setLoading(false);
-      return;
-    } else if (
-      applicationData.resume_link === null ||
-      applicationData.resume_link === ''
-    ) {
-      toast.error('Please provide a resume link!');
-      setLoading(false);
-      return;
-    } else if (
-      applicationData.position === null ||
-      applicationData.position === ''
-    ) {
-      toast.error('Please enter a position!');
-      setLoading(false);
-      return;
-    } else if (applicationData.available_hours.length === 0) {
-      toast.error('Please enter your available hours!');
-      setLoading(false);
-      return;
-    } else if (applicationData.available_semesters.length === 0) {
-      toast.error('Please enter your available semesters!');
-      setLoading(false);
-      return;
-    } else if (coursesArray.length === 0) {
-      toast.error('Please enter your courses!');
-      setLoading(false);
-      return;
-    } else {
+    }
+
+    setFieldErrors({});
+    {
       const toastId = toast.loading('Processing application', {
         duration: 30000,
       });
@@ -359,6 +365,10 @@ export default function Application() {
                   id="firstName"
                   label="First Name"
                   autoFocus
+                  error={!!fieldErrors.firstName}
+                  helperText={fieldErrors.firstName ?? ' '}
+                  onChange={() => clearFieldError('firstName')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -371,6 +381,10 @@ export default function Application() {
                   label="Last Name"
                   name="lastName"
                   autoComplete="family-name"
+                  error={!!fieldErrors.lastName}
+                  helperText={fieldErrors.lastName ?? ' '}
+                  onChange={() => clearFieldError('lastName')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -382,8 +396,12 @@ export default function Application() {
                   id="email"
                   label="Email Address"
                   name="email"
+                  type="email"
                   autoComplete="email"
-                  helperText="Enter your UF email address. Example: gator@ufl.edu"
+                  error={!!fieldErrors.email}
+                  helperText={fieldErrors.email ?? 'Example: gator@ufl.edu'}
+                  onChange={() => clearFieldError('email')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -395,7 +413,11 @@ export default function Application() {
                   id="ufid"
                   label="UFID"
                   name="ufid"
-                  helperText="Enter your UFID. Example: 12345678"
+                  inputMode="numeric"
+                  error={!!fieldErrors.ufid}
+                  helperText={fieldErrors.ufid ?? '8-digit UF ID'}
+                  onChange={() => clearFieldError('ufid')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -408,8 +430,11 @@ export default function Application() {
                   label="Phone Number"
                   type="tel"
                   id="phone-number"
-                  autoComplete="phone-number"
-                  helperText="Enter your phone number. Example: 123-456-7890"
+                  autoComplete="tel"
+                  error={!!fieldErrors.phone}
+                  helperText={fieldErrors.phone ?? 'Example: 123-456-7890'}
+                  onChange={() => clearFieldError('phone')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -515,6 +540,15 @@ export default function Application() {
                   id="resumeLink"
                   label="Resume Link"
                   name="resumeLink"
+                  type="url"
+                  placeholder="https://drive.google.com/..."
+                  error={!!fieldErrors.resumeLink}
+                  helperText={
+                    fieldErrors.resumeLink ??
+                    'Paste a shareable Google Drive link.'
+                  }
+                  onChange={() => clearFieldError('resumeLink')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -540,6 +574,10 @@ export default function Application() {
                   multiline
                   rows={8}
                   variant="filled"
+                  error={!!fieldErrors.qualifications}
+                  helperText={fieldErrors.qualifications ?? ' '}
+                  onChange={() => clearFieldError('qualifications')}
+                  sx={modernInputSx}
                 />
               </Grid>
 

--- a/src/app/applications/supervisedTeaching/page.tsx
+++ b/src/app/applications/supervisedTeaching/page.tsx
@@ -19,7 +19,39 @@ import MenuItem from '@mui/material/MenuItem';
 import InputLabel from '@mui/material/InputLabel';
 import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
+import FormHelperText from '@mui/material/FormHelperText';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Checkbox from '@mui/material/Checkbox';
 import { callFunction } from '@/firebase/functions/callFunction';
+import { modernInputSx } from '@/components/FormStyles';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const UFID_RE = /^\d{8}$/;
+
+type FieldErrors = Partial<
+  Record<
+    | 'firstName'
+    | 'lastName'
+    | 'ufid'
+    | 'email'
+    | 'confirmEmail'
+    | 'registerTerm'
+    | 'coursesComfortable'
+    | 'captcha',
+    string
+  >
+>;
+
+const TEACHING_AREAS = [
+  'Devices',
+  'Electromagnetics & Energy Systems',
+  'Electronics',
+  'Computer Systems',
+  'Digital Design',
+  'Signals & Systems',
+] as const;
 
 export default function SupervisedTeachingApplication() {
   const { user } = useAuth();
@@ -33,6 +65,15 @@ export default function SupervisedTeachingApplication() {
   const [teachingFirstChoice, setTeachingFirstChoice] = React.useState('');
   const [teachingSecondChoice, setTeachingSecondChoice] = React.useState('');
   const [teachingThirdChoice, setTeachingThirdChoice] = React.useState('');
+
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({});
+  const clearFieldError = (key: keyof FieldErrors) =>
+    setFieldErrors((prev) => {
+      if (!prev[key]) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
 
   const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
     props,
@@ -76,37 +117,33 @@ export default function SupervisedTeachingApplication() {
     const teachingThird = teachingThirdChoice || '';
     const captcha = formData.get('captcha') === 'on';
 
-    // basic validations
-    if (!email.includes('ufl.edu')) {
-      toast.error('Please enter a valid GatorLink (ufl.edu) email');
+    const nextErrors: FieldErrors = {};
+    if (!firstName.trim()) nextErrors.firstName = 'First name is required.';
+    if (!lastName.trim()) nextErrors.lastName = 'Last name is required.';
+    if (!ufid.trim()) nextErrors.ufid = 'UFID is required.';
+    else if (!UFID_RE.test(ufid)) nextErrors.ufid = 'UFID must be 8 digits.';
+    if (!email.trim()) nextErrors.email = 'Email is required.';
+    else if (!EMAIL_RE.test(email))
+      nextErrors.email = 'Enter a valid email address.';
+    else if (!email.toLowerCase().endsWith('ufl.edu'))
+      nextErrors.email = 'Must be a ufl.edu email.';
+    if (!confirmEmail.trim())
+      nextErrors.confirmEmail = 'Please confirm your email.';
+    else if (email !== confirmEmail)
+      nextErrors.confirmEmail = 'Emails do not match.';
+    if (!registerTerm) nextErrors.registerTerm = 'Please select a term.';
+    if (!coursesComfortable.trim())
+      nextErrors.coursesComfortable =
+        'List at least one course you could teach.';
+    if (!captcha) nextErrors.captcha = 'Please confirm you are not a robot.';
+
+    if (Object.keys(nextErrors).length > 0) {
+      setFieldErrors(nextErrors);
+      toast.error('Please fix the highlighted fields.');
       setLoading(false);
       return;
     }
-    if (email !== confirmEmail) {
-      toast.error('Email and Confirm Email must match');
-      setLoading(false);
-      return;
-    }
-    if (!firstName || !lastName || !ufid) {
-      toast.error('Please complete all required personal fields');
-      setLoading(false);
-      return;
-    }
-    if (!registerTerm) {
-      toast.error('Please select the term you want to register for EEL 6940');
-      setLoading(false);
-      return;
-    }
-    if (!coursesComfortable) {
-      toast.error('Please list at least one course you could teach');
-      setLoading(false);
-      return;
-    }
-    if (!captcha) {
-      toast.error('Please complete the CAPTCHA confirmation');
-      setLoading(false);
-      return;
-    }
+    setFieldErrors({});
 
     // date
     const current = new Date();
@@ -191,6 +228,11 @@ export default function SupervisedTeachingApplication() {
                   fullWidth
                   id="firstName"
                   label="First Name"
+                  autoComplete="given-name"
+                  error={!!fieldErrors.firstName}
+                  helperText={fieldErrors.firstName ?? ' '}
+                  onChange={() => clearFieldError('firstName')}
+                  sx={modernInputSx}
                 />
               </Grid>
               <Grid item xs={12} sm={6}>
@@ -201,6 +243,11 @@ export default function SupervisedTeachingApplication() {
                   fullWidth
                   id="lastName"
                   label="Last Name"
+                  autoComplete="family-name"
+                  error={!!fieldErrors.lastName}
+                  helperText={fieldErrors.lastName ?? ' '}
+                  onChange={() => clearFieldError('lastName')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -212,6 +259,11 @@ export default function SupervisedTeachingApplication() {
                   fullWidth
                   id="ufid"
                   label="UFID"
+                  inputMode="numeric"
+                  error={!!fieldErrors.ufid}
+                  helperText={fieldErrors.ufid ?? '8-digit UF ID'}
+                  onChange={() => clearFieldError('ufid')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -223,6 +275,12 @@ export default function SupervisedTeachingApplication() {
                   fullWidth
                   id="email"
                   label="UF Email Address"
+                  type="email"
+                  autoComplete="email"
+                  error={!!fieldErrors.email}
+                  helperText={fieldErrors.email ?? 'Example: gator@ufl.edu'}
+                  onChange={() => clearFieldError('email')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -234,6 +292,11 @@ export default function SupervisedTeachingApplication() {
                   fullWidth
                   id="confirmEmail"
                   label="Confirm Email"
+                  type="email"
+                  error={!!fieldErrors.confirmEmail}
+                  helperText={fieldErrors.confirmEmail ?? ' '}
+                  onChange={() => clearFieldError('confirmEmail')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -244,6 +307,8 @@ export default function SupervisedTeachingApplication() {
                   fullWidth
                   id="phdAdmissionTerm"
                   label="PhD Admission Term"
+                  helperText="e.g. Fall 2023"
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -254,28 +319,27 @@ export default function SupervisedTeachingApplication() {
                   fullWidth
                   id="phdAdvisor"
                   label="PhD Faculty Advisor"
+                  helperText=" "
+                  sx={modernInputSx}
                 />
               </Grid>
 
               <Grid item xs={12} sm={6}>
-                <Typography variant="subtitle2">
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
                   Admitted to candidacy? (registered for EEL 7980 hours)
                 </Typography>
-                <div>
-                  <label>
-                    <input
-                      type="radio"
-                      name="admittedToCandidacy"
-                      value="Yes"
-                    />{' '}
-                    Yes
-                  </label>
-                  <span style={{ marginLeft: 12 }} />
-                  <label>
-                    <input type="radio" name="admittedToCandidacy" value="No" />{' '}
-                    No
-                  </label>
-                </div>
+                <RadioGroup row name="admittedToCandidacy">
+                  <FormControlLabel
+                    value="Yes"
+                    control={<Radio size="small" />}
+                    label="Yes"
+                  />
+                  <FormControlLabel
+                    value="No"
+                    control={<Radio size="small" />}
+                    label="No"
+                  />
+                </RadioGroup>
               </Grid>
 
               <Grid item xs={12} sm={6}>
@@ -288,6 +352,10 @@ export default function SupervisedTeachingApplication() {
                   label="Which term to register for EEL 6940"
                   defaultValue=""
                   SelectProps={{ displayEmpty: true }}
+                  error={!!fieldErrors.registerTerm}
+                  helperText={fieldErrors.registerTerm ?? ' '}
+                  onChange={() => clearFieldError('registerTerm')}
+                  sx={modernInputSx}
                 >
                   <MenuItem value="">Select term</MenuItem>
                   {visibleSems.map((s) => (
@@ -299,28 +367,21 @@ export default function SupervisedTeachingApplication() {
               </Grid>
 
               <Grid item xs={12} sm={6}>
-                <Typography variant="subtitle2">
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
                   Previously registered for EEL 6940?
                 </Typography>
-                <div>
-                  <label>
-                    <input
-                      type="radio"
-                      name="previouslyRegistered"
-                      value="Yes"
-                    />{' '}
-                    Yes
-                  </label>
-                  <span style={{ marginLeft: 12 }} />
-                  <label>
-                    <input
-                      type="radio"
-                      name="previouslyRegistered"
-                      value="No"
-                    />{' '}
-                    No
-                  </label>
-                </div>
+                <RadioGroup row name="previouslyRegistered">
+                  <FormControlLabel
+                    value="Yes"
+                    control={<Radio size="small" />}
+                    label="Yes"
+                  />
+                  <FormControlLabel
+                    value="No"
+                    control={<Radio size="small" />}
+                    label="No"
+                  />
+                </RadioGroup>
               </Grid>
 
               <Grid item xs={12}>
@@ -330,6 +391,8 @@ export default function SupervisedTeachingApplication() {
                   fullWidth
                   id="previousDetails"
                   label="If so, which semester/course/who did you help?"
+                  helperText=" "
+                  sx={modernInputSx}
                 />
               </Grid>
 
@@ -343,111 +406,80 @@ export default function SupervisedTeachingApplication() {
                   minRows={2}
                   id="coursesComfortable"
                   label="Course(s) you would be comfortable teaching"
+                  error={!!fieldErrors.coursesComfortable}
+                  helperText={fieldErrors.coursesComfortable ?? ' '}
+                  onChange={() => clearFieldError('coursesComfortable')}
+                  sx={modernInputSx}
                 />
               </Grid>
 
-              <Grid item xs={12} sm={4}>
-                <FormControl fullWidth variant="filled">
-                  <InputLabel id="teaching-first-label">
-                    Teaching First Choice
-                  </InputLabel>
-                  <Select
-                    labelId="teaching-first-label"
-                    id="teachingFirst"
-                    value={teachingFirstChoice}
-                    label="Teaching First Choice"
-                    onChange={(e: SelectChangeEvent) =>
-                      setTeachingFirstChoice(e.target.value as string)
-                    }
-                  >
-                    <MenuItem value="">Select</MenuItem>
-                    <MenuItem value="Devices">Devices</MenuItem>
-                    <MenuItem value="Electromagnetics & Energy Systems">
-                      Electromagnetics & Energy Systems
-                    </MenuItem>
-                    <MenuItem value="Electronics">Electronics</MenuItem>
-                    <MenuItem value="Computer Systems">
-                      Computer Systems
-                    </MenuItem>
-                    <MenuItem value="Digital Design">Digital Design</MenuItem>
-                    <MenuItem value="Signals & Systems">
-                      Signals & Systems
-                    </MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-
-              <Grid item xs={12} sm={4}>
-                <FormControl fullWidth variant="filled">
-                  <InputLabel id="teaching-second-label">
-                    Teaching Second Choice
-                  </InputLabel>
-                  <Select
-                    labelId="teaching-second-label"
-                    id="teachingSecond"
-                    value={teachingSecondChoice}
-                    label="Teaching Second Choice"
-                    onChange={(e: SelectChangeEvent) =>
-                      setTeachingSecondChoice(e.target.value as string)
-                    }
-                  >
-                    <MenuItem value="">Select</MenuItem>
-                    <MenuItem value="Devices">Devices</MenuItem>
-                    <MenuItem value="Electromagnetics & Energy Systems">
-                      Electromagnetics & Energy Systems
-                    </MenuItem>
-                    <MenuItem value="Electronics">Electronics</MenuItem>
-                    <MenuItem value="Computer Systems">
-                      Computer Systems
-                    </MenuItem>
-                    <MenuItem value="Digital Design">Digital Design</MenuItem>
-                    <MenuItem value="Signals & Systems">
-                      Signals & Systems
-                    </MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-
-              <Grid item xs={12} sm={4}>
-                <FormControl fullWidth variant="filled">
-                  <InputLabel id="teaching-third-label">
-                    Teaching Third Choice
-                  </InputLabel>
-                  <Select
-                    labelId="teaching-third-label"
-                    id="teachingThird"
-                    value={teachingThirdChoice}
-                    label="Teaching Third Choice"
-                    onChange={(e: SelectChangeEvent) =>
-                      setTeachingThirdChoice(e.target.value as string)
-                    }
-                  >
-                    <MenuItem value="">Select</MenuItem>
-                    <MenuItem value="Devices">Devices</MenuItem>
-                    <MenuItem value="Electromagnetics & Energy Systems">
-                      Electromagnetics & Energy Systems
-                    </MenuItem>
-                    <MenuItem value="Electronics">Electronics</MenuItem>
-                    <MenuItem value="Computer Systems">
-                      Computer Systems
-                    </MenuItem>
-                    <MenuItem value="Digital Design">Digital Design</MenuItem>
-                    <MenuItem value="Signals & Systems">
-                      Signals & Systems
-                    </MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
+              {(
+                [
+                  ['first', teachingFirstChoice, setTeachingFirstChoice],
+                  ['second', teachingSecondChoice, setTeachingSecondChoice],
+                  ['third', teachingThirdChoice, setTeachingThirdChoice],
+                ] as const
+              ).map(([key, value, setValue]) => (
+                <Grid item xs={12} sm={4} key={key}>
+                  <FormControl fullWidth variant="filled" sx={modernInputSx}>
+                    <InputLabel id={`teaching-${key}-label`}>
+                      Teaching {key[0].toUpperCase() + key.slice(1)} Choice
+                    </InputLabel>
+                    <Select
+                      labelId={`teaching-${key}-label`}
+                      id={`teaching${key[0].toUpperCase() + key.slice(1)}`}
+                      value={value}
+                      label={`Teaching ${
+                        key[0].toUpperCase() + key.slice(1)
+                      } Choice`}
+                      onChange={(e: SelectChangeEvent) =>
+                        setValue(e.target.value as string)
+                      }
+                    >
+                      <MenuItem value="">Select</MenuItem>
+                      {TEACHING_AREAS.map((area) => (
+                        <MenuItem key={area} value={area}>
+                          {area}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Grid>
+              ))}
 
               <Grid item xs={12}>
-                <label>
-                  <input type="checkbox" name="captcha" /> I am not a robot
-                </label>
+                <FormControl error={!!fieldErrors.captcha}>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        name="captcha"
+                        onChange={() => clearFieldError('captcha')}
+                      />
+                    }
+                    label="I am not a robot"
+                  />
+                  {fieldErrors.captcha && (
+                    <FormHelperText>{fieldErrors.captcha}</FormHelperText>
+                  )}
+                </FormControl>
               </Grid>
 
               <Grid item xs={12} sx={{ mt: 2 }}>
-                <Button type="submit" variant="contained" disabled={loading}>
-                  Submit Request
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={loading}
+                  sx={{
+                    textTransform: 'none',
+                    fontWeight: 600,
+                    bgcolor: '#6739B7',
+                    px: 3,
+                    py: 1.25,
+                    borderRadius: 2,
+                    '&:hover': { bgcolor: '#522DA8' },
+                  }}
+                >
+                  {loading ? 'Submitting...' : 'Submit Request'}
                 </Button>
               </Grid>
             </Grid>

--- a/src/component/LogInCard/LogInCard.tsx
+++ b/src/component/LogInCard/LogInCard.tsx
@@ -1,276 +1,298 @@
 'use client';
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
 import { getAuth, sendPasswordResetEmail } from 'firebase/auth';
-
-import React from 'react';
-import Dialog from '@mui/material/Dialog';
-import Button from '@mui/material/Button';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import Divider from '@mui/material/Divider';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
-import handleSignIn from '../../firebase/auth/auth_signin_password';
-import { useState } from 'react';
-import './style.css';
-import MuiAlert, { AlertProps } from '@mui/material/Alert';
-import { TextField } from '@mui/material';
-import Link from 'next/link';
-import FormControl from '@mui/material/FormControl';
 import { toast } from 'react-hot-toast';
 
-import 'firebase/firestore';
+import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import TextField from '@mui/material/TextField';
+import CircularProgress from '@mui/material/CircularProgress';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+
+import { PrimaryButton, GhostButton } from '@/components/Buttons/PrimaryButton';
+import handleSignIn from '../../firebase/auth/auth_signin_password';
+
+type LoginValues = { email: string; password: string };
+type ResetValues = { resetEmail: string };
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const cardSx = {
+  width: { xs: '100%', sm: 480, md: 539 },
+  maxWidth: '100%',
+  bgcolor: '#fff',
+  borderRadius: 5,
+  boxShadow: '0px 4px 35px rgba(0,0,0,0.08)',
+  p: { xs: 3, sm: 4.5 },
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2.5,
+};
+
+const inputSx = {
+  '& .MuiOutlinedInput-root': {
+    borderRadius: 2.5,
+    bgcolor: '#fafafa',
+    '& fieldset': { borderColor: '#e3e3e3' },
+    '&:hover fieldset': { borderColor: '#bbb' },
+    '&.Mui-focused fieldset': { borderColor: '#6739B7', borderWidth: 2 },
+  },
+  '& .MuiInputLabel-root.Mui-focused': { color: '#6739B7' },
+};
+
 export const LogInCard = ({
   className,
   setSignup,
 }: {
-  className: any;
+  className?: string;
   setSignup: (val: boolean) => void;
 }) => {
-  var res;
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  const [email, setEmail] = useState('');
-  const [emailVal, setEmailVal] = useState('');
-  const [password, setPassword] = useState('');
-  const [open, setOpen] = React.useState(false);
-  const handleClose = () => {
-    setOpen(false);
-  };
+  const [showPassword, setShowPassword] = React.useState(false);
+  const [resetOpen, setResetOpen] = React.useState(false);
 
-  const handleForgotPassword = (e: any) => {
-    //handleSignOut();
-    e.preventDefault();
-    const auth = getAuth();
-    sendPasswordResetEmail(auth, emailVal)
-      .then(() => {
-        // Password reset email sent!
-        // ..
-        toast.success('Password reset email sent!');
-      })
-      .catch((error) => {
-        const errorCode = error.code;
-        const errorMessage = error.message;
-        // ..
-        console.log(error);
-      });
-    setOpen(false);
-  };
-  const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
-    props,
-    ref
-  ) {
-    return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
-  });
-  const handleSubmit = async (event: any) => {
-    setLoading(true);
-    event.preventDefault();
-    res = await handleSignIn(email, password);
-    // Loading bar toggle
-    if (!res) {
-      setLoading(false);
-    } else {
-      setSuccess(true);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginValues>({ mode: 'onBlur' });
+
+  const {
+    register: registerReset,
+    handleSubmit: handleSubmitReset,
+    reset: resetResetForm,
+    formState: { errors: resetErrors, isSubmitting: resetSubmitting },
+  } = useForm<ResetValues>({ mode: 'onBlur' });
+
+  const onSubmit = async ({ email, password }: LoginValues) => {
+    const ok = await handleSignIn(email.trim(), password);
+    if (!ok) {
+      // handleSignIn already toasts on failure
+      return;
     }
   };
+
+  const onReset = async ({ resetEmail }: ResetValues) => {
+    try {
+      await sendPasswordResetEmail(getAuth(), resetEmail.trim());
+      toast.success('Password reset email sent!');
+      setResetOpen(false);
+      resetResetForm();
+    } catch (err: any) {
+      toast.error(
+        err?.code === 'auth/user-not-found'
+          ? 'No account found for that email.'
+          : 'Could not send reset email. Try again.'
+      );
+    }
+  };
+
   return (
-    <div className={`log-in-card ${className}`}>
+    <Box className={className} sx={cardSx}>
+      <Box>
+        <Box
+          component="h1"
+          sx={{
+            m: 0,
+            fontSize: { xs: 40, sm: 48 },
+            fontWeight: 600,
+            color: '#111',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          Log In
+        </Box>
+        <Divider
+          sx={{ mt: 1.5, borderColor: '#6b46c1', borderBottomWidth: 2 }}
+        />
+      </Box>
+
+      <Box
+        component="form"
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+        sx={{ display: 'flex', flexDirection: 'column', gap: 2.25 }}
+      >
+        <TextField
+          label="Email"
+          placeholder="email@ufl.edu"
+          type="email"
+          fullWidth
+          autoFocus
+          autoComplete="email"
+          error={!!errors.email}
+          helperText={errors.email?.message ?? ' '}
+          sx={inputSx}
+          {...register('email', {
+            required: 'Email is required.',
+            pattern: {
+              value: EMAIL_RE,
+              message: 'Enter a valid email address.',
+            },
+          })}
+        />
+
+        <TextField
+          label="Password"
+          placeholder="Enter your password"
+          type={showPassword ? 'text' : 'password'}
+          fullWidth
+          autoComplete="current-password"
+          error={!!errors.password}
+          helperText={errors.password?.message ?? ' '}
+          sx={inputSx}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  onClick={() => setShowPassword((v) => !v)}
+                  edge="end"
+                  size="small"
+                >
+                  {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+          {...register('password', {
+            required: 'Password is required.',
+            minLength: { value: 6, message: 'At least 6 characters.' },
+          })}
+        />
+
+        <PrimaryButton
+          type="submit"
+          aria-label="Log in"
+          disabled={isSubmitting}
+          w="100%"
+          h={50}
+          radius={2.5}
+          sx={{
+            fontSize: 16,
+            fontWeight: 600,
+            mt: 0.5,
+            boxShadow: '0px 4px 19px rgba(119,147,65,0.3)',
+          }}
+        >
+          {isSubmitting ? (
+            <CircularProgress size={22} sx={{ color: '#fff' }} />
+          ) : (
+            'Log In'
+          )}
+        </PrimaryButton>
+
+        <Box sx={{ textAlign: 'center', mt: 0.5 }}>
+          <GhostButton
+            type="button"
+            w="auto"
+            h="auto"
+            onClick={() => setResetOpen(true)}
+            sx={{ textDecoration: 'underline', fontSize: 14, p: 0.5 }}
+          >
+            Forgot Password?
+          </GhostButton>
+        </Box>
+
+        <Box sx={{ textAlign: 'center', fontSize: 14, color: '#555' }}>
+          Don&apos;t have an account?{' '}
+          <GhostButton
+            type="button"
+            w="auto"
+            h="auto"
+            onClick={() => setSignup(true)}
+            sx={{
+              textDecoration: 'underline',
+              fontSize: 14,
+              p: 0.5,
+              minWidth: 0,
+            }}
+          >
+            Sign Up
+          </GhostButton>
+        </Box>
+      </Box>
+
       <Dialog
-        style={{
-          borderImage:
-            'linear-gradient(to bottom, rgb(9, 251, 211), rgb(255, 111, 241)) 1',
-          boxShadow: '0px 2px 20px 4px #00000040',
-          borderRadius: '20px',
-          border: '2px solid',
-        }}
+        open={resetOpen}
+        onClose={() => setResetOpen(false)}
         PaperProps={{
-          style: { borderRadius: 20 },
+          sx: {
+            borderRadius: 3,
+            p: { xs: 1, sm: 2 },
+            maxWidth: 480,
+          },
         }}
-        open={open}
-        onClose={handleClose}
       >
         <DialogTitle
-          style={{
-            fontFamily: 'SF Pro Display-Medium, Helvetica',
-            textAlign: 'center',
-            fontSize: '40px',
-            fontWeight: '540',
-          }}
+          sx={{ textAlign: 'center', fontSize: 28, fontWeight: 600, pb: 1 }}
         >
           Reset Password
         </DialogTitle>
-        <form onSubmit={(e) => handleForgotPassword(e)}>
+        <Box component="form" onSubmit={handleSubmitReset(onReset)} noValidate>
           <DialogContent>
             <DialogContentText
-              style={{
-                marginTop: '35px',
-                fontFamily: 'SF Pro Display-Medium, Helvetica',
-                textAlign: 'center',
-                fontSize: '20px',
-                color: 'black',
-              }}
+              sx={{ textAlign: 'center', fontSize: 15, color: '#333', mb: 3 }}
             >
-              Please enter the email associated with your account. This allows
-              us to send you a link where you can reset the account password.
+              Enter the email associated with your account and we&apos;ll send
+              you a link to reset your password.
             </DialogContentText>
-            <br />
-            <br />
-
-            <FormControl required>
-              <TextField
-                style={{ left: '160px' }}
-                name="email"
-                variant="filled"
-                onChange={(val) => setEmailVal(val.target.value)}
-                required
-                fullWidth
-                id="email"
-                label="Email"
-                autoFocus
-              />
-            </FormControl>
+            <TextField
+              label="Email"
+              type="email"
+              fullWidth
+              autoFocus
+              error={!!resetErrors.resetEmail}
+              helperText={resetErrors.resetEmail?.message ?? ' '}
+              sx={inputSx}
+              {...registerReset('resetEmail', {
+                required: 'Email is required.',
+                pattern: {
+                  value: EMAIL_RE,
+                  message: 'Enter a valid email address.',
+                },
+              })}
+            />
           </DialogContent>
-          <DialogActions
-            style={{
-              marginTop: '30px',
-              marginBottom: '42px',
-              display: 'flex',
-              justifyContent: 'space-between',
-              gap: '93px',
-            }}
-          >
-            <Button
-              variant="outlined"
-              style={{
-                fontSize: '17px',
-                marginLeft: '110px',
-                borderRadius: '10px',
-                height: '43px',
-                width: '120px',
-                textTransform: 'none',
-                fontFamily: 'SF Pro Display-Bold , Helvetica',
-                borderColor: '#5736ac',
-                color: '#5736ac',
-                borderWidth: '3px',
+          <DialogActions sx={{ px: 3, pb: 3, gap: 2 }}>
+            <GhostButton
+              type="button"
+              onClick={() => setResetOpen(false)}
+              w={120}
+              h={44}
+              radius={2.5}
+              sx={{
+                border: '2px solid #6739B7',
+                fontWeight: 600,
               }}
-              onClick={handleClose}
             >
               Cancel
-            </Button>
-
-            <Button
-              variant="contained"
-              style={{
-                fontSize: '17px',
-                marginRight: '110px',
-                borderRadius: '10px',
-                height: '43px',
-                width: '120px',
-                textTransform: 'none',
-                fontFamily: 'SF Pro Display-Bold , Helvetica',
-                backgroundColor: '#5736ac',
-                color: '#ffffff',
-              }}
+            </GhostButton>
+            <PrimaryButton
               type="submit"
+              disabled={resetSubmitting}
+              w={120}
+              h={44}
+              radius={2.5}
+              sx={{ fontWeight: 600 }}
             >
-              Reset
-            </Button>
+              {resetSubmitting ? (
+                <CircularProgress size={20} sx={{ color: '#fff' }} />
+              ) : (
+                'Reset'
+              )}
+            </PrimaryButton>
           </DialogActions>
-        </form>
+        </Box>
       </Dialog>
-      <form
-        onSubmit={(e) => {
-          void handleSubmit(e);
-        }}
-      >
-        <div className="div">Log In</div>
-        <Divider
-          sx={{
-            position: 'absolute',
-            top: '115px',
-            left: '30px',
-            width: '475px',
-            borderBottomWidth: 2,
-            borderColor: '#6b46c1',
-          }}
-        />
-
-        <div className="email-address-input">
-          <div className="text-wrapper-2">Email</div>
-          <div className="overlap-group-wrapper">
-            <div className="overlap-group">
-              <TextField
-                label="Email"
-                variant="outlined"
-                placeholder="email@ufl.edu"
-                required
-                fullWidth
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setEmail(event.target.value);
-                }}
-                id="email"
-                name="email"
-                autoComplete="email"
-                autoFocus
-              />
-            </div>
-          </div>
-        </div>
-        <div className="password-input">
-          <div className="text-wrapper-2">Password</div>
-          <div className="overlap-group-wrapper">
-            <div className="overlap-group">
-              <TextField
-                label="Password"
-                variant="outlined"
-                placeholder="1234567890"
-                required
-                fullWidth
-                name="password"
-                type="password"
-                id="password"
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setPassword(event.target.value);
-                }}
-                autoComplete="current-password"
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className="sign-in-button">
-          <button
-            type="submit"
-            aria-label="Log in"
-            onClick={(e) => handleSubmit(e)}
-            className="overlap"
-          >
-            <div className="text-wrapper-5">Log In</div>
-          </button>
-        </div>
-        <div className="password-forgot-text">
-          <button
-            type="button"
-            aria-label="Forgot Password"
-            className="cursor-pointer underline hover:no-underline"
-            onClick={(e) => setOpen(true)}
-          >
-            Forgot Password?
-          </button>
-        </div>
-
-        <div className="sign-up-text">
-          <span className="text-gray-300">Don&apos;t have an account? </span>
-          <br />
-          <button
-            type="button"
-            aria-label="Sign up"
-            className="cursor-pointer underline hover:no-underline"
-            onClick={() => setSignup(true)}
-          >
-            {'Sign Up'}
-          </button>
-        </div>
-      </form>
-    </div>
+    </Box>
   );
 };

--- a/src/component/SignUpCard/SignUpCard.tsx
+++ b/src/component/SignUpCard/SignUpCard.tsx
@@ -1,163 +1,142 @@
 'use client';
-import React, { useState } from 'react';
-import { MenuItem, Snackbar, TextField, Divider } from '@mui/material';
-import MuiAlert, { AlertProps } from '@mui/material/Alert';
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import CircularProgress from '@mui/material/CircularProgress';
+import LinearProgress from '@mui/material/LinearProgress';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+
+import { PrimaryButton, GhostButton } from '@/components/Buttons/PrimaryButton';
 import handleSignUp from '../../firebase/auth/auth_signup_password';
 import handleSignIn from '@/firebase/auth/auth_signin_password';
 import { callFunction } from '@/firebase/functions/callFunction';
 import firebase from '@/firebase/firebase_config';
 
-import styles from './style.module.css';
+type SignUpValues = {
+  firstName: string;
+  lastName: string;
+  role: '' | 'student_applying' | 'unapproved';
+  department: string;
+  email: string;
+  ufid: string;
+  password: string;
+  confirmPassword: string;
+};
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const NAME_RE = /^[A-Za-z][A-Za-z\s'-]*$/;
+
+const DEPARTMENTS = ['ECE', 'CS', 'MSE', 'ISE', 'MAE', 'BME', 'NRE'] as const;
+
+const cardSx = {
+  width: { xs: '100%', sm: 480, md: 539 },
+  maxWidth: '100%',
+  bgcolor: '#fff',
+  borderRadius: 5,
+  boxShadow: '0px 4px 35px rgba(0,0,0,0.08)',
+  p: { xs: 3, sm: 4.5 },
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2.25,
+};
+
+const inputSx = {
+  '& .MuiOutlinedInput-root': {
+    borderRadius: 2.5,
+    bgcolor: '#fafafa',
+    '& fieldset': { borderColor: '#e3e3e3' },
+    '&:hover fieldset': { borderColor: '#bbb' },
+    '&.Mui-focused fieldset': { borderColor: '#6739B7', borderWidth: 2 },
+  },
+  '& .MuiInputLabel-root.Mui-focused': { color: '#6739B7' },
+};
+
+function scorePassword(pw: string): { score: number; label: string } {
+  if (!pw) return { score: 0, label: '' };
+  let score = 0;
+  if (pw.length >= 8) score++;
+  if (/[A-Z]/.test(pw)) score++;
+  if (/[a-z]/.test(pw)) score++;
+  if (/[0-9]/.test(pw)) score++;
+  if (/[!@#$%^&*()_+{}\[\]:;<>,.?~\\/-]/.test(pw)) score++;
+  const label =
+    score <= 2
+      ? 'Weak'
+      : score === 3
+      ? 'Fair'
+      : score === 4
+      ? 'Good'
+      : 'Strong';
+  return { score, label };
+}
 
 export const SignUpCard = ({
   className,
   setSignup,
 }: {
-  className: any;
+  className?: string;
   setSignup?: (val: boolean) => void;
 }) => {
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [password, setPassword] = useState('');
-  const [ufid, setUFID] = useState('');
-  const [department, setDepartment] = useState('');
-  const [role, setRole] = useState('');
-  const [confirmedPassword, setConfirmedPassword] = useState('');
-  const [email, setEmail] = useState('');
-  const [label, setLabel] = useState('ECE');
-  const [roleLabel, setRoleLabel] = useState('Student');
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
+  const [showPassword, setShowPassword] = React.useState(false);
+  const [showConfirm, setShowConfirm] = React.useState(false);
 
-  const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
-    props,
-    ref
-  ) {
-    return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<SignUpValues>({
+    mode: 'onBlur',
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      role: '',
+      department: '',
+      email: '',
+      ufid: '',
+      password: '',
+      confirmPassword: '',
+    },
   });
 
-  const handleNotificationEmail = async (
-    safeFirstName: string,
-    safeLastName: string,
-    safeEmail: string
-  ) => {
-    if (role === 'unapproved') {
-      try {
-        await callFunction(
-          'sendEmail',
-          {
-            type: 'unapprovedUser',
-            data: {
-              user: {
-                name: `${safeFirstName} ${safeLastName}`.trim(),
-                email: safeEmail,
-              },
-            },
-          },
-          { requireAuth: false }
-        );
-      } catch (error) {
-        console.error('Error sending unapproved user email:', error);
-      }
-    }
-  };
+  const password = watch('password');
+  const { score, label: strengthLabel } = scorePassword(password);
+  const strengthColor =
+    score <= 2
+      ? '#d32f2f'
+      : score === 3
+      ? '#ed6c02'
+      : score >= 4
+      ? '#2e7d32'
+      : '#bbb';
 
-  function isStrongPassword(password: string): boolean {
-    if (password.length < 8) {
-      toast.error('Password should contain at least 8 characters!');
-      return false;
-    }
-
-    const uppercaseRegex = /[A-Z]/;
-    const lowercaseRegex = /[a-z]/;
-    const numberRegex = /[0-9]/;
-    const specialCharacterRegex = /[!@#$%^&*()_+{}\[\]:;<>,.?~\\/-]/;
-
-    if (!uppercaseRegex.test(password)) {
-      toast.error('Password should contain at least one uppercase letter!');
-      return false;
-    }
-    if (!lowercaseRegex.test(password)) {
-      toast.error('Password should contain at least one lowercase letter!');
-      return false;
-    }
-    if (!numberRegex.test(password)) {
-      toast.error('Password should contain at least one number!');
-      return false;
-    }
-    if (!specialCharacterRegex.test(password)) {
-      toast.error('Password should contain at least one special character!');
-      return false;
-    }
-
-    return true;
-  }
-
-  const handleSubmit = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    setLoading(true);
-
+  const onSubmit = async (values: SignUpValues) => {
     try {
-      const safeFirstName = firstName.trim();
-      const safeLastName = lastName.trim();
-      const safeEmail = email.trim();
-      const safeDepartment = department.trim();
-      const safeRole = role.trim();
-      const safeUFID = ufid.trim() || '00000000';
-
-      if (safeFirstName === '') {
-        toast.error('Please enter a first name!');
-        return;
-      }
-      if (/[0-9]/.test(safeFirstName)) {
-        toast.error('First name should only contain letters!');
-        return;
-      }
-      if (safeLastName === '') {
-        toast.error('Please enter a last name!');
-        return;
-      }
-      if (safeRole === '') {
-        toast.error('Please select a role!');
-        return;
-      }
-      if (safeDepartment === '') {
-        toast.error('Please select a department!');
-        return;
-      }
-      if (safeEmail === '') {
-        toast.error('Please enter an email!');
-        return;
-      }
-      if (password === '') {
-        toast.error('Please enter a password!');
-        return;
-      }
-      if (confirmedPassword !== password) {
-        toast.error('Passwords should match!');
-        return;
-      }
-      if (!isStrongPassword(password)) {
-        return;
-      }
-
+      const safeFirstName = values.firstName.trim();
+      const safeLastName = values.lastName.trim();
+      const safeEmail = values.email.trim();
+      const safeUFID = values.ufid.trim() || '00000000';
       const fullName = `${safeFirstName} ${safeLastName}`.trim();
 
-      const uidFromSignup = await handleSignUp(fullName, safeEmail, password);
-
-      console.log('signup returned uid/code:', uidFromSignup);
+      const uidFromSignup = await handleSignUp(
+        fullName,
+        safeEmail,
+        values.password
+      );
 
       if (uidFromSignup === '-1' || uidFromSignup === '') {
         toast.error('This UFID is already in use!');
         return;
       }
-      if (
-        uidFromSignup === '-2' ||
-        uidFromSignup === '-3' ||
-        uidFromSignup === '-4'
-      ) {
+      if (['-2', '-3', '-4'].includes(uidFromSignup)) {
         toast.error('Please enter a valid email address!');
         return;
       }
@@ -166,286 +145,327 @@ export const SignUpCard = ({
         return;
       }
 
-      const userProfilePayload = {
-        firstname: safeFirstName,
-        lastname: safeLastName,
-        email: safeEmail,
-        department: safeDepartment,
-        role: safeRole,
-        ufid: safeUFID,
-        uid: uidFromSignup,
-        created_at: firebase.firestore.FieldValue.serverTimestamp(),
-        updated_at: firebase.firestore.FieldValue.serverTimestamp(),
-      };
+      await firebase.firestore().collection('users').doc(uidFromSignup).set(
+        {
+          firstname: safeFirstName,
+          lastname: safeLastName,
+          email: safeEmail,
+          department: values.department,
+          role: values.role,
+          ufid: safeUFID,
+          uid: uidFromSignup,
+          created_at: firebase.firestore.FieldValue.serverTimestamp(),
+          updated_at: firebase.firestore.FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
 
-      console.log('about to write users doc');
-      console.log('payload:', userProfilePayload);
+      if (values.role === 'unapproved') {
+        try {
+          await callFunction(
+            'sendEmail',
+            {
+              type: 'unapprovedUser',
+              data: {
+                user: { name: fullName, email: safeEmail },
+              },
+            },
+            { requireAuth: false }
+          );
+        } catch (err) {
+          console.error('Error sending unapproved user email:', err);
+        }
+      }
 
-      await firebase
-        .firestore()
-        .collection('users')
-        .doc(uidFromSignup)
-        .set(userProfilePayload, { merge: true });
-
-      setSuccess(true);
-      console.log('SUCCESS: User data written to users collection');
-
-      await handleNotificationEmail(safeFirstName, safeLastName, safeEmail);
-      await handleSignIn(safeEmail, password);
+      toast.success('Signup successful!');
+      await handleSignIn(safeEmail, values.password);
     } catch (err: any) {
       console.error('user doc write failed:', err);
       toast.error(err?.message || 'Failed to create user profile');
-    } finally {
-      setLoading(false);
     }
   };
 
   return (
-    <div className={styles.box}>
-      <Snackbar open={success} autoHideDuration={3000}>
-        <Alert severity="info" sx={{ width: '100%' }}>
-          Signup successful!
-        </Alert>
-      </Snackbar>
+    <Box className={className} sx={cardSx}>
+      <Box>
+        <Box
+          component="h1"
+          sx={{
+            m: 0,
+            fontSize: { xs: 40, sm: 48 },
+            fontWeight: 600,
+            color: '#111',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          Sign Up
+        </Box>
+        <Divider
+          sx={{ mt: 1.5, borderColor: '#6b46c1', borderBottomWidth: 2 }}
+        />
+      </Box>
 
-      <div className={className}>
-        <div className={styles.overlap}>
-          <div className={styles.div}>Sign Up</div>
-
-          <Divider
-            sx={{
-              position: 'absolute',
-              top: '115px',
-              left: '30px',
-              width: '475px',
-              borderBottomWidth: 2,
-              borderColor: '#6b46c1',
-            }}
+      <Box
+        component="form"
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+        sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+      >
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+            gap: 2,
+          }}
+        >
+          <TextField
+            label="First Name"
+            placeholder="Albert"
+            fullWidth
+            autoFocus
+            autoComplete="given-name"
+            error={!!errors.firstName}
+            helperText={errors.firstName?.message ?? ' '}
+            sx={inputSx}
+            {...register('firstName', {
+              required: 'First name is required.',
+              pattern: {
+                value: NAME_RE,
+                message: 'Letters, spaces, hyphens only.',
+              },
+            })}
           />
+          <TextField
+            label="Last Name"
+            placeholder="Einstein"
+            fullWidth
+            autoComplete="family-name"
+            error={!!errors.lastName}
+            helperText={errors.lastName?.message ?? ' '}
+            sx={inputSx}
+            {...register('lastName', {
+              required: 'Last name is required.',
+              pattern: {
+                value: NAME_RE,
+                message: 'Letters, spaces, hyphens only.',
+              },
+            })}
+          />
+        </Box>
 
-          <div className={styles.firstnameinput}>
-            <div className={styles.textwrapper2}>First Name</div>
-            <div className={styles.overlapgroupwrapper}>
-              <div className={styles.overlapgroup}>
-                <TextField
-                  variant="outlined"
-                  InputProps={{ disableUnderline: true }}
-                  className={styles.textwrapper3}
-                  placeholder="Albert"
-                  required
-                  fullWidth
+        <TextField
+          label="Email"
+          placeholder="email@ufl.edu"
+          type="email"
+          fullWidth
+          autoComplete="email"
+          error={!!errors.email}
+          helperText={errors.email?.message ?? ' '}
+          sx={inputSx}
+          {...register('email', {
+            required: 'Email is required.',
+            pattern: { value: EMAIL_RE, message: 'Enter a valid email.' },
+            validate: (v) =>
+              v.toLowerCase().endsWith('ufl.edu') || 'Must be a ufl.edu email.',
+          })}
+        />
+
+        <TextField
+          label="UFID"
+          placeholder="12345678"
+          fullWidth
+          inputMode="numeric"
+          error={!!errors.ufid}
+          helperText={errors.ufid?.message ?? ' '}
+          sx={inputSx}
+          {...register('ufid', {
+            required: 'UFID is required.',
+            pattern: { value: /^\d{8}$/, message: 'UFID must be 8 digits.' },
+          })}
+        />
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+            gap: 2,
+          }}
+        >
+          <TextField
+            label="Department"
+            select
+            fullWidth
+            defaultValue=""
+            error={!!errors.department}
+            helperText={errors.department?.message ?? ' '}
+            sx={inputSx}
+            {...register('department', {
+              required: 'Please select a department.',
+            })}
+          >
+            {DEPARTMENTS.map((d) => (
+              <MenuItem key={d} value={d}>
+                {d}
+              </MenuItem>
+            ))}
+          </TextField>
+
+          <TextField
+            label="Role"
+            select
+            fullWidth
+            defaultValue=""
+            error={!!errors.role}
+            helperText={errors.role?.message ?? ' '}
+            sx={inputSx}
+            {...register('role', { required: 'Please select a role.' })}
+          >
+            <MenuItem value="student_applying">Student</MenuItem>
+            <MenuItem value="unapproved">Faculty</MenuItem>
+          </TextField>
+        </Box>
+
+        <TextField
+          label="Password"
+          placeholder="At least 8 characters"
+          type={showPassword ? 'text' : 'password'}
+          fullWidth
+          autoComplete="new-password"
+          error={!!errors.password}
+          helperText={errors.password?.message ?? ' '}
+          sx={inputSx}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  onClick={() => setShowPassword((v) => !v)}
+                  edge="end"
                   size="small"
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setFirstName(event.target.value);
-                  }}
-                  id="first-name"
-                  name="first-name"
-                  autoComplete="given-name"
-                  autoFocus
-                />
-              </div>
-            </div>
-          </div>
+                >
+                  {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+          {...register('password', {
+            required: 'Password is required.',
+            minLength: { value: 8, message: 'At least 8 characters.' },
+            validate: {
+              upper: (v) => /[A-Z]/.test(v) || 'Include an uppercase letter.',
+              lower: (v) => /[a-z]/.test(v) || 'Include a lowercase letter.',
+              number: (v) => /[0-9]/.test(v) || 'Include a number.',
+              special: (v) =>
+                /[!@#$%^&*()_+{}\[\]:;<>,.?~\\/-]/.test(v) ||
+                'Include a special character.',
+            },
+          })}
+        />
 
-          <div className={styles.roleinput}>
-            <div className={styles.textwrapper4}>Role</div>
-            <div className={styles.overlapgroup2}>
-              <TextField
-                sx={{ borderRadius: '30px' }}
-                value={role}
-                placeholder="Set Role"
-                InputLabelProps={{ shrink: false }}
-                label={roleLabel}
-                size="small"
-                select
-                onChange={(event) => {
-                  setRole(event.target.value);
-                  setRoleLabel('');
-                }}
-                className={styles.textwrapper9}
-              >
-                <MenuItem value={'student_applying'}>Student</MenuItem>
-                <MenuItem value={'unapproved'}>Faculty</MenuItem>
-              </TextField>
-            </div>
-          </div>
-
-          <div className={styles.lastnameinput}>
-            <div className={styles.textwrapper10}>Last Name</div>
-            <div className={styles.overlapgroupwrapper}>
-              <div className={styles.overlapgroup}>
-                <TextField
-                  variant="outlined"
-                  InputProps={{ disableUnderline: true }}
-                  className={styles.textwrapper3}
-                  placeholder="Einstein"
-                  required
-                  fullWidth
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setLastName(event.target.value);
-                  }}
-                  id="last-name"
-                  name="last-name"
-                  size="small"
-                  autoComplete="family-name"
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className={styles.departmentinput}>
-            <div className={styles.textwrapper4}>Department</div>
-            <div className={styles.overlapgroup2}>
-              <TextField
-                sx={{ borderRadius: '30px' }}
-                value={department}
-                placeholder="Set Department"
-                InputLabelProps={{ shrink: false }}
-                label={label}
-                size="small"
-                select
-                onChange={(event) => {
-                  setDepartment(event.target.value);
-                  setLabel('');
-                }}
-                className={styles.textwrapper9}
-              >
-                <MenuItem value={'ECE'}>ECE</MenuItem>
-                <MenuItem value={'CS'}>CS</MenuItem>
-                <MenuItem value={'MSE'}>MSE</MenuItem>
-                <MenuItem value={'ISE'}>ISE</MenuItem>
-                <MenuItem value={'MAE'}>MAE</MenuItem>
-                <MenuItem value={'BME'}>BME</MenuItem>
-                <MenuItem value={'NRE'}>NRE</MenuItem>
-              </TextField>
-            </div>
-          </div>
-
-          <div className={styles.emailaddressinput}>
-            <div className={styles.textwrapper11}>Enter email address</div>
-            <div className={styles.divwrapper}>
-              <div className={styles.overlapgroup3}>
-                <TextField
-                  variant="outlined"
-                  InputProps={{ disableUnderline: true }}
-                  className={styles.textwrapperlongbox}
-                  placeholder="email@ufl.edu"
-                  required
-                  fullWidth
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setEmail(event.target.value);
-                  }}
-                  id="email"
-                  name="email"
-                  size="small"
-                  autoComplete="email"
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className={styles.ufidinput}>
-            <div className={styles.textwrapper11}>UFID</div>
-            <div className={styles.divwrapper}>
-              <div className={styles.overlapgroup3}>
-                <TextField
-                  variant="outlined"
-                  InputProps={{ disableUnderline: true }}
-                  className={styles.textwrapperlongbox}
-                  placeholder="12345678"
-                  required
-                  fullWidth
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setUFID(event.target.value);
-                  }}
-                  id="ufid"
-                  name="ufid"
-                  size="small"
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className={styles.passwordinput}>
-            <div className={styles.textwrapper13}>Enter password</div>
-            <div className={styles.textwrapper14}>Confirm password</div>
-
-            <div className={styles.divwrapper}>
-              <div className={styles.overlapgroup3}>
-                <TextField
-                  variant="outlined"
-                  InputProps={{ disableUnderline: true }}
-                  className={styles.textwrapperlongbox}
-                  placeholder="1234567890"
-                  required
-                  size="small"
-                  fullWidth
-                  name="password"
-                  type="password"
-                  id="password"
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setPassword(event.target.value);
-                  }}
-                  autoComplete="new-password"
-                />
-              </div>
-            </div>
-
-            <div className={styles.confirmpassword}>
-              <div className={styles.overlapgroup3}>
-                <TextField
-                  variant="outlined"
-                  InputProps={{ disableUnderline: true }}
-                  className={styles.textwrapperlongbox}
-                  placeholder="1234567890"
-                  required
-                  size="small"
-                  fullWidth
-                  name="confirm-password"
-                  type="password"
-                  id="confirm-password"
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setConfirmedPassword(event.target.value);
-                  }}
-                  autoComplete="new-password"
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className={styles.facultytext}>
-            *If you are going to create a <strong>Faculty</strong> account,
-            please make sure to sign up using the same email that you use for
-            Onbase/Course Registration.
-          </div>
-
-          <div className={styles.signintext}>
-            <span className="text-gray-300">Already have an account? </span>
-            <br />
-            <button
-              type="button"
-              className="cursor-pointer underline hover:no-underline"
-              onClick={() => setSignup?.(false)}
+        {password && (
+          <Box sx={{ mt: -1 }}>
+            <LinearProgress
+              variant="determinate"
+              value={(score / 5) * 100}
+              sx={{
+                height: 6,
+                borderRadius: 3,
+                bgcolor: '#eee',
+                '& .MuiLinearProgress-bar': { bgcolor: strengthColor },
+              }}
+            />
+            <Box
+              sx={{
+                fontSize: 12,
+                color: strengthColor,
+                mt: 0.5,
+                fontWeight: 500,
+              }}
             >
-              Log In
-            </button>
-          </div>
+              Strength: {strengthLabel}
+            </Box>
+          </Box>
+        )}
 
-          <div className={styles.signinbutton}>
-            <br />
-            <button
-              type="button"
-              onClick={handleSubmit}
-              className={styles.overlap2}
-              disabled={loading}
-            >
-              <div className={styles.textwrapper16}>
-                {loading ? 'Signing up...' : 'Sign up'}
-              </div>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+        <TextField
+          label="Confirm Password"
+          placeholder="Re-enter password"
+          type={showConfirm ? 'text' : 'password'}
+          fullWidth
+          autoComplete="new-password"
+          error={!!errors.confirmPassword}
+          helperText={errors.confirmPassword?.message ?? ' '}
+          sx={inputSx}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={showConfirm ? 'Hide password' : 'Show password'}
+                  onClick={() => setShowConfirm((v) => !v)}
+                  edge="end"
+                  size="small"
+                >
+                  {showConfirm ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+          {...register('confirmPassword', {
+            required: 'Please confirm your password.',
+            validate: (v) => v === password || 'Passwords do not match.',
+          })}
+        />
+
+        <Box
+          sx={{
+            fontSize: 12,
+            color: '#4D4D4D',
+            fontWeight: 300,
+            lineHeight: 1.5,
+          }}
+        >
+          *If you are creating a <strong>Faculty</strong> account, please sign
+          up using the same email you use for Onbase/Course Registration.
+        </Box>
+
+        <PrimaryButton
+          type="submit"
+          disabled={isSubmitting}
+          w="100%"
+          h={50}
+          radius={2.5}
+          sx={{
+            fontSize: 16,
+            fontWeight: 600,
+            mt: 0.5,
+            boxShadow: '0px 4px 19px rgba(119,147,65,0.3)',
+          }}
+        >
+          {isSubmitting ? (
+            <CircularProgress size={22} sx={{ color: '#fff' }} />
+          ) : (
+            'Sign Up'
+          )}
+        </PrimaryButton>
+
+        <Box sx={{ textAlign: 'center', fontSize: 14, color: '#555' }}>
+          Already have an account?{' '}
+          <GhostButton
+            type="button"
+            w="auto"
+            h="auto"
+            onClick={() => setSignup?.(false)}
+            sx={{
+              textDecoration: 'underline',
+              fontSize: 14,
+              p: 0.5,
+              minWidth: 0,
+            }}
+          >
+            Log In
+          </GhostButton>
+        </Box>
+      </Box>
+    </Box>
   );
 };

--- a/src/components/FormStyles.ts
+++ b/src/components/FormStyles.ts
@@ -1,0 +1,19 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export const modernInputSx: SxProps<Theme> = {
+  '& .MuiOutlinedInput-root': {
+    borderRadius: 2.5,
+    bgcolor: '#fafafa',
+    '& fieldset': { borderColor: '#e3e3e3' },
+    '&:hover fieldset': { borderColor: '#bbb' },
+    '&.Mui-focused fieldset': { borderColor: '#6739B7', borderWidth: 2 },
+  },
+  '& .MuiFilledInput-root': {
+    borderRadius: 2.5,
+    bgcolor: '#fafafa',
+    '&:hover': { bgcolor: '#f3f3f3' },
+    '&.Mui-focused': { bgcolor: '#f3f3f3' },
+    '&:before, &:after': { display: 'none' },
+  },
+  '& .MuiInputLabel-root.Mui-focused': { color: '#6739B7' },
+};


### PR DESCRIPTION
Auth cards (LogInCard, SignUpCard):
- Replace absolute-positioned CSS with flex/grid layouts
- Adopt react-hook-form for field-level validation with inline helperText
- Email format + ufl.edu check, 8-digit UFID, password strength meter
- Password visibility toggles, loading spinners, shared PrimaryButton

Student application forms (courseAssistant, supervisedTeaching):
- Replace serial if/else toast chains with a field-errors map and inline red helperText on each invalid input
- Add email, UFID, phone, and URL format validation
- Swap raw HTML radio/checkbox for MUI RadioGroup/Checkbox
- Dedupe the three copy-pasted teaching-area selects

Shared:
- Add src/components/FormStyles.ts (modernInputSx) so outlined/filled inputs share the same rounded, purple-focus treatment