### PR TITLE
feat(departments): add department entity, per-user roles, and invite …

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -145,5 +145,36 @@ service cloud.firestore {
       allow create, update: if isAdmin();
       allow delete: if isSelf(uid) || isAdmin();
     }
+
+    // --------- departments (Unit 2+) ---------
+    // Any authed user may read the departments list (used by pickers, research
+    // filters, announcement audience UI). Writes are restricted to super
+    // admins via Cloud Function (admin SDK bypasses rules); we still deny
+    // client writes here as defense-in-depth.
+    match /departments/{deptId} {
+      allow read: if isAuthed();
+      allow write: if false;
+    }
+
+    // --------- pending memberships (Unit 4) ---------
+    // The invitee needs to read their own pending doc to see that an invite
+    // exists; admins/super admins need read+delete to manage the list.
+    // Writes go through Cloud Functions (admin SDK) only.
+    match /pendingMemberships/{email} {
+      allow read: if isAuthed()
+                  && (request.auth.token.email != null
+                      && request.auth.token.email.lower() == email);
+      allow read: if isAdmin();
+      allow write: if false;
+    }
+
+    // --------- login events (audit trail; writes only) ---------
+    // auth_context.js appends a row on first sign-in per session. No one
+    // reads these from the client today.
+    match /login_events/{eventId} {
+      allow read: if false;
+      allow create: if isAuthed();
+      allow update, delete: if false;
+    }
   }
 }

--- a/functions/src/departments.ts
+++ b/functions/src/departments.ts
@@ -1,0 +1,254 @@
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import {
+  asRecord,
+  db,
+  ensureSuperAdmin,
+  fail,
+  handleMethod,
+  readString,
+  setCors,
+  verifyAuth,
+} from './index';
+
+// --- validation ---
+
+const CODE_PATTERN = /^[A-Z]{2,6}$/;
+const NAME_MIN = 1;
+const NAME_MAX = 120;
+
+type Department = {
+  id: string;
+  code: string;
+  name: string;
+  status: 'active' | 'archived';
+  createdAt: admin.firestore.FieldValue;
+  archivedAt?: admin.firestore.FieldValue;
+};
+
+function codeToId(code: string): string {
+  return code.toLowerCase();
+}
+
+function validateCode(
+  code: unknown
+): { ok: true; value: string } | { ok: false; error: string } {
+  if (typeof code !== 'string' || !CODE_PATTERN.test(code)) {
+    return {
+      ok: false,
+      error: 'Code must be uppercase A–Z only, 2–6 characters.',
+    };
+  }
+  return { ok: true, value: code };
+}
+
+function validateName(
+  name: unknown
+): { ok: true; value: string } | { ok: false; error: string } {
+  if (typeof name !== 'string') {
+    return { ok: false, error: 'Name is required.' };
+  }
+  const trimmed = name.trim();
+  if (trimmed.length < NAME_MIN || trimmed.length > NAME_MAX) {
+    return {
+      ok: false,
+      error: `Name must be between ${NAME_MIN} and ${NAME_MAX} characters.`,
+    };
+  }
+  return { ok: true, value: trimmed };
+}
+
+// Check that no department record exists with this code (active or archived).
+// Codes are never reused to keep historical references unambiguous.
+async function ensureCodeUnused(code: string): Promise<boolean> {
+  const id = codeToId(code);
+  const direct = await db.collection('departments').doc(id).get();
+  if (direct.exists) return false;
+
+  // Also scan for any older doc that might have used the same code under a
+  // different id. Cheap at this scale (tiny departments collection).
+  const dup = await db
+    .collection('departments')
+    .where('code', '==', code)
+    .limit(1)
+    .get();
+  return dup.empty;
+}
+
+// --- endpoints ---
+
+export const createDepartment = functions.https.onRequest(async (req, res) => {
+  setCors(req, res);
+  if (!handleMethod(req, res)) return;
+
+  const caller = await verifyAuth(req, res);
+  if (!caller) return;
+  const ok = await ensureSuperAdmin(caller.uid, res);
+  if (!ok) return;
+
+  try {
+    const body = asRecord(req.body);
+    const codeCheck = validateCode(readString(body, 'code'));
+    if (!codeCheck.ok) {
+      fail(res, codeCheck.error);
+      return;
+    }
+    const nameCheck = validateName(readString(body, 'name'));
+    if (!nameCheck.ok) {
+      fail(res, nameCheck.error);
+      return;
+    }
+
+    const code = codeCheck.value;
+    const name = nameCheck.value;
+    const id = codeToId(code);
+
+    const unused = await ensureCodeUnused(code);
+    if (!unused) {
+      fail(res, `Department code ${code} is already in use.`, 409);
+      return;
+    }
+
+    const doc: Department = {
+      id,
+      code,
+      name,
+      status: 'active',
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    };
+    await db.collection('departments').doc(id).set(doc);
+
+    res.status(200).json({ id, code, name, status: 'active' });
+  } catch (error) {
+    console.error('createDepartment failed:', error);
+    fail(res, 'Error creating department', 500);
+  }
+});
+
+export const updateDepartment = functions.https.onRequest(async (req, res) => {
+  setCors(req, res);
+  if (!handleMethod(req, res)) return;
+
+  const caller = await verifyAuth(req, res);
+  if (!caller) return;
+  const ok = await ensureSuperAdmin(caller.uid, res);
+  if (!ok) return;
+
+  try {
+    const body = asRecord(req.body);
+    const id = readString(body, 'id');
+    if (!id) {
+      fail(res, 'Missing department id');
+      return;
+    }
+
+    const ref = db.collection('departments').doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      fail(res, 'Department not found', 404);
+      return;
+    }
+
+    const updates: Record<string, unknown> = {};
+    const rawName = readString(body, 'name');
+    if (rawName !== undefined) {
+      const nameCheck = validateName(rawName);
+      if (!nameCheck.ok) {
+        fail(res, nameCheck.error);
+        return;
+      }
+      updates.name = nameCheck.value;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      fail(res, 'No editable fields provided');
+      return;
+    }
+
+    await ref.update(updates);
+    res.status(200).json({ id, ...updates });
+  } catch (error) {
+    console.error('updateDepartment failed:', error);
+    fail(res, 'Error updating department', 500);
+  }
+});
+
+export const archiveDepartment = functions.https.onRequest(async (req, res) => {
+  setCors(req, res);
+  if (!handleMethod(req, res)) return;
+
+  const caller = await verifyAuth(req, res);
+  if (!caller) return;
+  const ok = await ensureSuperAdmin(caller.uid, res);
+  if (!ok) return;
+
+  try {
+    const body = asRecord(req.body);
+    const id = readString(body, 'id');
+    if (!id) {
+      fail(res, 'Missing department id');
+      return;
+    }
+
+    const ref = db.collection('departments').doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      fail(res, 'Department not found', 404);
+      return;
+    }
+    if (snap.data()?.status === 'archived') {
+      res.status(200).json({ id, status: 'archived', alreadyArchived: true });
+      return;
+    }
+
+    await ref.update({
+      status: 'archived',
+      archivedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    res.status(200).json({ id, status: 'archived' });
+  } catch (error) {
+    console.error('archiveDepartment failed:', error);
+    fail(res, 'Error archiving department', 500);
+  }
+});
+
+export const unarchiveDepartment = functions.https.onRequest(
+  async (req, res) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+    const ok = await ensureSuperAdmin(caller.uid, res);
+    if (!ok) return;
+
+    try {
+      const body = asRecord(req.body);
+      const id = readString(body, 'id');
+      if (!id) {
+        fail(res, 'Missing department id');
+        return;
+      }
+
+      const ref = db.collection('departments').doc(id);
+      const snap = await ref.get();
+      if (!snap.exists) {
+        fail(res, 'Department not found', 404);
+        return;
+      }
+      if (snap.data()?.status !== 'archived') {
+        res.status(200).json({ id, status: 'active', alreadyActive: true });
+        return;
+      }
+
+      await ref.update({
+        status: 'active',
+        archivedAt: admin.firestore.FieldValue.delete(),
+      });
+      res.status(200).json({ id, status: 'active' });
+    } catch (error) {
+      console.error('unarchiveDepartment failed:', error);
+      fail(res, 'Error unarchiving department', 500);
+    }
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -50,7 +50,7 @@ type EmailType =
 
 type ApplicationType = 'course_assistant' | 'supervised_teaching';
 
-function setCors(req: Request, res: Response): void {
+export function setCors(req: Request, res: Response): void {
   const origin = req.get('origin');
   res.set('Vary', 'Origin');
   if (origin && ALLOWED_ORIGINS.has(origin)) {
@@ -60,7 +60,7 @@ function setCors(req: Request, res: Response): void {
   res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 }
 
-function handleMethod(req: Request, res: Response): boolean {
+export function handleMethod(req: Request, res: Response): boolean {
   if (req.method === 'OPTIONS') {
     res.status(204).send('');
     return false;
@@ -80,13 +80,13 @@ function getBearerToken(req: Request): string | null {
   return authHeader.substring('Bearer '.length).trim();
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
+export function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object'
     ? (value as Record<string, unknown>)
     : {};
 }
 
-function readString(
+export function readString(
   source: Record<string, unknown>,
   key: string
 ): string | undefined {
@@ -122,7 +122,7 @@ function readApplicationType(value: unknown): ApplicationType | null {
   return null;
 }
 
-async function verifyAuth(
+export async function verifyAuth(
   req: Request,
   res: Response
 ): Promise<admin.auth.DecodedIdToken | null> {
@@ -141,7 +141,7 @@ async function verifyAuth(
   }
 }
 
-async function getRole(uid: string): Promise<string> {
+export async function getRole(uid: string): Promise<string> {
   const snap = await db.collection('users').doc(uid).get();
   const data = snap.data() as Record<string, unknown> | undefined;
   return typeof data?.role === 'string' ? data.role : '';
@@ -156,9 +156,29 @@ async function ensureStaffRole(uid: string, res: Response): Promise<boolean> {
   return true;
 }
 
-function fail(res: Response, message: string, code = 400): void {
+export function fail(res: Response, message: string, code = 400): void {
   res.status(code).json({ message });
 }
+
+// Verify the caller is a super admin. Reads users/{uid}.superAdmin directly —
+// this is the bootstrap gate until claims-backed roles land in Unit 3, and
+// the `superAdmin` field is protected from client writes by firestore.rules.
+export async function ensureSuperAdmin(
+  uid: string,
+  res: Response
+): Promise<boolean> {
+  const snap = await db.collection('users').doc(uid).get();
+  const data = snap.data() as Record<string, unknown> | undefined;
+  if (data?.superAdmin !== true) {
+    res.status(403).json({ message: 'Forbidden — super admin only' });
+    return false;
+  }
+  return true;
+}
+
+// The shared Firestore + Auth handles so new Cloud Function files don't
+// re-initialize the SDK.
+export { db, auth };
 
 export const sendEmail = functions.https.onRequest(async (req, res) => {
   setCors(req, res);
@@ -624,3 +644,25 @@ export const deleteUserFromID = functions.https.onRequest(
     }
   }
 );
+
+// --- multi-department support (Unit 2+) ---
+
+export {
+  createDepartment,
+  updateDepartment,
+  archiveDepartment,
+  unarchiveDepartment,
+} from './departments';
+
+export {
+  setRole,
+  revokeRole,
+  promoteSuperAdmin,
+  demoteSuperAdmin,
+} from './roles';
+
+export {
+  createPendingMembership,
+  revokePendingMembership,
+  materializePendingMemberships,
+} from './invites';

--- a/functions/src/invites.ts
+++ b/functions/src/invites.ts
@@ -1,0 +1,381 @@
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import {
+  asRecord,
+  auth,
+  db,
+  ensureSuperAdmin,
+  fail,
+  handleMethod,
+  readString,
+  setCors,
+  verifyAuth,
+} from './index';
+import { sendInviteNotificationEmail } from './nodemailer';
+
+// Pending-memberships pattern (Unit 4 of multi-department support).
+//
+// An admin creates `pendingMemberships/{emailLower}` with the role they want
+// the invitee to hold. When the invitee first signs in (via processSignUpForm
+// for brand-new users, or via an explicit call from useCurrentUser for
+// existing ones), `materializePendingMemberships` reads the doc, writes the
+// role into `users/{uid}.roles[]`, and deletes the pending doc.
+//
+// Deliberately no signed tokens, no TTLs, no single-use enforcement, and no
+// bound oobCodes. The invite doc is idempotent: re-creating it just refreshes
+// `invitedAt`; deleting it is the revoke path; a second click after
+// materialization is a no-op.
+
+type PerDeptRole = 'admin' | 'faculty';
+
+function parseRole(value: unknown): PerDeptRole | null {
+  return value === 'admin' || value === 'faculty' ? value : null;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+const SIGN_IN_URL =
+  process.env.INVITE_SIGN_IN_URL ?? 'https://courseconnect.eng.ufl.edu';
+
+async function departmentActive(deptId: string): Promise<{
+  exists: boolean;
+  active: boolean;
+  name: string | null;
+}> {
+  const snap = await db.collection('departments').doc(deptId).get();
+  if (!snap.exists) return { exists: false, active: false, name: null };
+  const data = snap.data() as Record<string, unknown>;
+  return {
+    exists: true,
+    active: data.status !== 'archived',
+    name: typeof data.name === 'string' ? (data.name as string) : null,
+  };
+}
+
+async function callerAdminsDept(
+  callerUid: string,
+  deptId: string
+): Promise<boolean> {
+  const snap = await db.collection('users').doc(callerUid).get();
+  const data = snap.data() as Record<string, unknown> | undefined;
+  if (!data) return false;
+  if (data.superAdmin === true) return true;
+  const adminIds = Array.isArray(data.adminOfDepartmentIds)
+    ? (data.adminOfDepartmentIds as unknown[]).filter(
+        (v): v is string => typeof v === 'string'
+      )
+    : [];
+  if (adminIds.includes(deptId)) return true;
+  // Legacy transition fallback.
+  if (data.role === 'admin' && typeof data.department === 'string') {
+    return data.department.toLowerCase() === deptId;
+  }
+  return false;
+}
+
+// --- endpoints ---
+
+export const createPendingMembership = functions.https.onRequest(
+  async (req, res) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+
+    try {
+      const body = asRecord(req.body);
+      const rawEmail = readString(body, 'email');
+      const deptId = readString(body, 'deptId');
+      const role = parseRole(body.role);
+      if (!rawEmail || !deptId || !role) {
+        fail(res, 'Missing email, deptId, or role');
+        return;
+      }
+      const email = normalizeEmail(rawEmail);
+
+      // Authorization: admin-role invites require super admin; faculty-role
+      // invites require dept admin or super admin.
+      if (role === 'admin') {
+        const ok = await ensureSuperAdmin(caller.uid, res);
+        if (!ok) return;
+      } else {
+        const allowed = await callerAdminsDept(caller.uid, deptId);
+        if (!allowed) {
+          res.status(403).json({ message: 'Forbidden' });
+          return;
+        }
+      }
+
+      const dept = await departmentActive(deptId);
+      if (!dept.exists) {
+        fail(res, 'Unknown department', 404);
+        return;
+      }
+      if (!dept.active) {
+        fail(res, 'Department is archived; cannot invite.', 409);
+        return;
+      }
+
+      // Single-admin-per-user: if inviting someone to admin a dept and they
+      // already hold admin elsewhere (pending or materialized), reject.
+      if (role === 'admin') {
+        let alreadyAdmin = false;
+
+        const pending = await db
+          .collection('pendingMemberships')
+          .where('email', '==', email)
+          .where('role', '==', 'admin')
+          .limit(1)
+          .get();
+        if (!pending.empty && pending.docs[0].data().deptId !== deptId) {
+          alreadyAdmin = true;
+        }
+
+        if (!alreadyAdmin) {
+          try {
+            const user = await auth.getUserByEmail(email);
+            const userSnap = await db.collection('users').doc(user.uid).get();
+            const existing = userSnap.data()?.roles;
+            if (Array.isArray(existing)) {
+              for (const r of existing) {
+                if (
+                  r &&
+                  typeof r === 'object' &&
+                  (r as Record<string, unknown>).role === 'admin' &&
+                  (r as Record<string, unknown>).deptId !== deptId
+                ) {
+                  alreadyAdmin = true;
+                  break;
+                }
+              }
+            }
+          } catch (err) {
+            // User doesn't exist in Auth yet — no conflict possible.
+          }
+        }
+
+        if (alreadyAdmin) {
+          fail(
+            res,
+            `${email} already holds admin in a different department. Revoke first.`,
+            409
+          );
+          return;
+        }
+      }
+
+      // Look up inviter's display name for the email body.
+      const inviterSnap = await db.collection('users').doc(caller.uid).get();
+      const inviterData = inviterSnap.data() as
+        | Record<string, unknown>
+        | undefined;
+      const inviterName =
+        (typeof inviterData?.firstname === 'string'
+          ? (inviterData.firstname as string)
+          : '') +
+        (typeof inviterData?.lastname === 'string'
+          ? ` ${inviterData.lastname as string}`
+          : '');
+      const inviterLabel = inviterName.trim() || 'a Course Connect admin';
+
+      const now = admin.firestore.FieldValue.serverTimestamp();
+      await db
+        .collection('pendingMemberships')
+        .doc(email)
+        .set(
+          {
+            email,
+            deptId,
+            role,
+            deptName: dept.name ?? deptId.toUpperCase(),
+            invitedBy: caller.uid,
+            invitedByName: inviterLabel,
+            invitedAt: now,
+          },
+          { merge: true }
+        );
+
+      // Best-effort email notification. Failure does not roll back the
+      // pending doc — the inviter can resend via the admin UI.
+      try {
+        await sendInviteNotificationEmail(
+          { email },
+          dept.name ?? deptId.toUpperCase(),
+          role === 'admin' ? 'admin' : 'faculty',
+          inviterLabel,
+          SIGN_IN_URL
+        );
+      } catch (err) {
+        console.error('Invite email dispatch failed (non-fatal):', err);
+        res.status(200).json({
+          email,
+          deptId,
+          role,
+          notificationEmailFailed: true,
+        });
+        return;
+      }
+
+      res.status(200).json({ email, deptId, role });
+    } catch (error) {
+      console.error('createPendingMembership failed:', error);
+      fail(res, 'Error creating invite', 500);
+    }
+  }
+);
+
+export const revokePendingMembership = functions.https.onRequest(
+  async (req, res) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+
+    try {
+      const body = asRecord(req.body);
+      const rawEmail = readString(body, 'email');
+      if (!rawEmail) {
+        fail(res, 'Missing email');
+        return;
+      }
+      const email = normalizeEmail(rawEmail);
+
+      const ref = db.collection('pendingMemberships').doc(email);
+      const snap = await ref.get();
+      if (!snap.exists) {
+        res.status(200).json({ email, alreadyGone: true });
+        return;
+      }
+
+      const data = snap.data() as Record<string, unknown>;
+      const deptId = typeof data.deptId === 'string' ? data.deptId : '';
+      const role = parseRole(data.role);
+
+      if (role === 'admin') {
+        const ok = await ensureSuperAdmin(caller.uid, res);
+        if (!ok) return;
+      } else {
+        const allowed = await callerAdminsDept(caller.uid, deptId);
+        if (!allowed) {
+          res.status(403).json({ message: 'Forbidden' });
+          return;
+        }
+      }
+
+      await ref.delete();
+      res.status(200).json({ email });
+    } catch (error) {
+      console.error('revokePendingMembership failed:', error);
+      fail(res, 'Error revoking invite', 500);
+    }
+  }
+);
+
+// Materialize any pending memberships for a user's verified email into their
+// users/{uid}.roles[]. Idempotent. Callable by the user themselves (most
+// common path) or by an authenticated client on mount as a safety net.
+export const materializePendingMemberships = functions.https.onRequest(
+  async (req, res) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+
+    try {
+      const callerEmail =
+        typeof caller.email === 'string' ? normalizeEmail(caller.email) : null;
+      if (!callerEmail) {
+        res.status(200).json({ materialized: 0, reason: 'no email on token' });
+        return;
+      }
+
+      const pendingRef = db.collection('pendingMemberships').doc(callerEmail);
+      const pendingSnap = await pendingRef.get();
+      if (!pendingSnap.exists) {
+        res.status(200).json({ materialized: 0 });
+        return;
+      }
+
+      const data = pendingSnap.data() as Record<string, unknown>;
+      const deptId = typeof data.deptId === 'string' ? data.deptId : '';
+      const role = parseRole(data.role);
+      if (!deptId || !role) {
+        // Corrupted pending doc — delete so it doesn't sit forever.
+        await pendingRef.delete();
+        res.status(200).json({ materialized: 0, reason: 'malformed pending' });
+        return;
+      }
+
+      const dept = await departmentActive(deptId);
+      if (!dept.exists || !dept.active) {
+        // Dept went away or was archived — surface this to the caller but
+        // keep the pending doc so an admin can see the orphan.
+        res.status(200).json({
+          materialized: 0,
+          reason: dept.exists ? 'department archived' : 'department missing',
+        });
+        return;
+      }
+
+      const userRef = db.collection('users').doc(caller.uid);
+      await db.runTransaction(async (tx) => {
+        const snap = await tx.get(userRef);
+        const existing = snap.exists
+          ? (snap.data()?.roles as unknown[]) ?? []
+          : [];
+        const already = Array.isArray(existing)
+          ? existing.some(
+              (r) =>
+                r &&
+                typeof r === 'object' &&
+                (r as Record<string, unknown>).deptId === deptId &&
+                (r as Record<string, unknown>).role === role
+            )
+          : false;
+
+        const next = already
+          ? existing
+          : [...(Array.isArray(existing) ? existing : []), { deptId, role }];
+
+        const adminIds = new Set<string>();
+        const facultyIds = new Set<string>();
+        for (const entry of next) {
+          if (entry && typeof entry === 'object') {
+            const r = entry as Record<string, unknown>;
+            if (r.role === 'admin' && typeof r.deptId === 'string') {
+              adminIds.add(r.deptId as string);
+            }
+            if (r.role === 'faculty' && typeof r.deptId === 'string') {
+              facultyIds.add(r.deptId as string);
+            }
+          }
+        }
+
+        tx.set(
+          userRef,
+          {
+            roles: next,
+            adminOfDepartmentIds: Array.from(adminIds).sort(),
+            facultyOfDepartmentIds: Array.from(facultyIds).sort(),
+            departmentIds: Array.from(
+              new Set([...adminIds, ...facultyIds])
+            ).sort(),
+          },
+          { merge: true }
+        );
+
+        tx.delete(pendingRef);
+      });
+
+      res.status(200).json({ materialized: 1, deptId, role });
+    } catch (error) {
+      console.error('materializePendingMemberships failed:', error);
+      fail(res, 'Error materializing pending memberships', 500);
+    }
+  }
+);

--- a/functions/src/nodemailer.ts
+++ b/functions/src/nodemailer.ts
@@ -189,7 +189,9 @@ export async function sendUnapprovedUserNotificationEmail(
       subject: 'New Unapproved User',
       text: `Dear Admin,\n\n${displayName(
         user
-      )} has recently created an account and is awaiting your approval. Please review ${user.email}'s account and approve or deny registration at your earliest convenience.\n\nBest regards,\nCourse Connect Team`,
+      )} has recently created an account and is awaiting your approval. Please review ${
+        user.email
+      }'s account and approve or deny registration at your earliest convenience.\n\nBest regards,\nCourse Connect Team`,
     },
     'Unapproved user notification email sent:'
   );
@@ -225,5 +227,40 @@ export async function sendRenewTAEmail(
       text: message,
     },
     'TA renewal email sent:'
+  );
+}
+
+// Unit 4 of multi-department support — notification email for pending-
+// memberships invites. The invite itself lives in Firestore; this email is
+// just a nudge telling the invitee to sign in. No time-limited tokens; the
+// pending doc materializes on their first authenticated session.
+export async function sendInviteNotificationEmail(
+  invitee: EmailUser,
+  deptName: string,
+  roleLabel: string,
+  inviterName: string,
+  signInUrl: string
+): Promise<void> {
+  const subject = `You've been added as ${roleLabel} of ${deptName} on Course Connect`;
+  const body = `Hi ${displayName(invitee)},
+
+${inviterName} has added you as ${roleLabel} of ${deptName} on Course Connect.
+
+To activate your access, sign in with your UF email at:
+${signInUrl}
+
+Your role will become active the first time you sign in. Nothing expires — if you sign in later, the invite will still apply.
+
+If you weren't expecting this, you can safely ignore the email or reach out to ${inviterName} directly.
+
+— Course Connect`;
+  await sendMail(
+    {
+      from: email,
+      to: invitee.email,
+      subject,
+      text: body,
+    },
+    'Invite notification email sent:'
   );
 }

--- a/functions/src/roles.ts
+++ b/functions/src/roles.ts
@@ -1,0 +1,351 @@
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import {
+  asRecord,
+  auth,
+  db,
+  ensureSuperAdmin,
+  fail,
+  handleMethod,
+  readString,
+  setCors,
+  verifyAuth,
+} from './index';
+
+// Per-department roles stored on the user doc. Plan: the `roles` array is the
+// authoritative shape; `adminOfDepartmentIds` / `facultyOfDepartmentIds` /
+// `departmentIds` are denormalized convenience fields maintained here so
+// Firestore rules can answer "does this user admin department X?" with a
+// cheap field-check instead of iterating the array.
+type PerDeptRole = 'admin' | 'faculty';
+
+interface RoleEntry {
+  deptId: string;
+  role: PerDeptRole;
+}
+
+function parseRole(value: unknown): PerDeptRole | null {
+  return value === 'admin' || value === 'faculty' ? value : null;
+}
+
+function sanitizeRoleEntries(value: unknown): RoleEntry[] {
+  if (!Array.isArray(value)) return [];
+  const out: RoleEntry[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue;
+    const rec = entry as Record<string, unknown>;
+    const deptId = typeof rec.deptId === 'string' ? rec.deptId : null;
+    const role = parseRole(rec.role);
+    if (deptId && role) out.push({ deptId, role });
+  }
+  return out;
+}
+
+function withEntry(
+  roles: RoleEntry[],
+  deptId: string,
+  role: PerDeptRole
+): RoleEntry[] {
+  // Single-admin-per-user is enforced at the caller level; here we just replace
+  // an existing (deptId, role) entry so re-invites are idempotent.
+  const remaining = roles.filter(
+    (r) => !(r.deptId === deptId && r.role === role)
+  );
+  remaining.push({ deptId, role });
+  return remaining;
+}
+
+function withoutEntry(
+  roles: RoleEntry[],
+  deptId: string,
+  role: PerDeptRole
+): RoleEntry[] {
+  return roles.filter((r) => !(r.deptId === deptId && r.role === role));
+}
+
+function deriveDenormalized(roles: RoleEntry[]) {
+  const adminIds = new Set<string>();
+  const facultyIds = new Set<string>();
+  for (const r of roles) {
+    if (r.role === 'admin') adminIds.add(r.deptId);
+    if (r.role === 'faculty') facultyIds.add(r.deptId);
+  }
+  const union = new Set<string>([...adminIds, ...facultyIds]);
+  return {
+    adminOfDepartmentIds: Array.from(adminIds).sort(),
+    facultyOfDepartmentIds: Array.from(facultyIds).sort(),
+    departmentIds: Array.from(union).sort(),
+  };
+}
+
+// Authorization for faculty-role mutations: super admin OR an active admin of
+// the target dept. Reads the caller's doc once. During the transition window
+// also honors the legacy `users/{uid}.role === 'admin'` + `department ===
+// deptId` signal so existing admins can invite faculty before the backfill
+// lands.
+async function canManageFacultyIn(
+  callerUid: string,
+  deptId: string
+): Promise<boolean> {
+  const snap = await db.collection('users').doc(callerUid).get();
+  const data = snap.data() as Record<string, unknown> | undefined;
+  if (!data) return false;
+  if (data.superAdmin === true) return true;
+
+  const adminIds = Array.isArray(data.adminOfDepartmentIds)
+    ? (data.adminOfDepartmentIds as unknown[]).filter(
+        (v): v is string => typeof v === 'string'
+      )
+    : [];
+  if (adminIds.includes(deptId)) return true;
+
+  // Legacy fallback (Unit 1..7 window).
+  if (data.role === 'admin' && typeof data.department === 'string') {
+    return data.department.toLowerCase() === deptId;
+  }
+  return false;
+}
+
+async function departmentExists(deptId: string): Promise<boolean> {
+  const snap = await db.collection('departments').doc(deptId).get();
+  return snap.exists;
+}
+
+async function applyRoleWrite(
+  uid: string,
+  mutate: (existing: RoleEntry[]) => RoleEntry[]
+): Promise<RoleEntry[]> {
+  const userRef = db.collection('users').doc(uid);
+  let next: RoleEntry[] = [];
+
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(userRef);
+    if (!snap.exists) {
+      // Initialize a minimal user doc so the role can land even if the user
+      // hasn't signed in yet (e.g., materialization from pendingMemberships).
+      tx.set(
+        userRef,
+        {
+          createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+    }
+    const existing = sanitizeRoleEntries(snap.data()?.roles);
+    next = mutate(existing);
+
+    const denorm = deriveDenormalized(next);
+    tx.set(
+      userRef,
+      {
+        roles: next,
+        ...denorm,
+      },
+      { merge: true }
+    );
+  });
+
+  return next;
+}
+
+// --- endpoints ---
+
+// setRole — grants (uid, deptId, role). Super admin may grant any role;
+// dept admin may grant only `faculty` in their own department.
+export const setRole = functions.https.onRequest(async (req, res) => {
+  setCors(req, res);
+  if (!handleMethod(req, res)) return;
+
+  const caller = await verifyAuth(req, res);
+  if (!caller) return;
+
+  try {
+    const body = asRecord(req.body);
+    const uid = readString(body, 'uid');
+    const deptId = readString(body, 'deptId');
+    const role = parseRole(body.role);
+
+    if (!uid || !deptId || !role) {
+      fail(res, 'Missing uid, deptId, or role');
+      return;
+    }
+
+    if (!(await departmentExists(deptId))) {
+      fail(res, 'Unknown department', 404);
+      return;
+    }
+
+    // Authorization: admin role requires super admin; faculty can be granted
+    // by super admin or by an admin of the same department.
+    if (role === 'admin') {
+      const ok = await ensureSuperAdmin(caller.uid, res);
+      if (!ok) return;
+    } else {
+      const allowed = await canManageFacultyIn(caller.uid, deptId);
+      if (!allowed) {
+        res.status(403).json({ message: 'Forbidden' });
+        return;
+      }
+    }
+
+    // Enforce single-admin-per-user this pass.
+    if (role === 'admin') {
+      const target = await db.collection('users').doc(uid).get();
+      const existing = sanitizeRoleEntries(target.data()?.roles);
+      const currentAdmin = existing.find((r) => r.role === 'admin');
+      if (currentAdmin && currentAdmin.deptId !== deptId) {
+        fail(
+          res,
+          `User already holds admin role in ${currentAdmin.deptId}. Revoke first.`,
+          409
+        );
+        return;
+      }
+    }
+
+    const next = await applyRoleWrite(uid, (existing) =>
+      withEntry(existing, deptId, role)
+    );
+    res.status(200).json({ uid, roles: next });
+  } catch (error) {
+    console.error('setRole failed:', error);
+    fail(res, 'Error setting role', 500);
+  }
+});
+
+export const revokeRole = functions.https.onRequest(async (req, res) => {
+  setCors(req, res);
+  if (!handleMethod(req, res)) return;
+
+  const caller = await verifyAuth(req, res);
+  if (!caller) return;
+
+  try {
+    const body = asRecord(req.body);
+    const uid = readString(body, 'uid');
+    const deptId = readString(body, 'deptId');
+    const role = parseRole(body.role);
+
+    if (!uid || !deptId || !role) {
+      fail(res, 'Missing uid, deptId, or role');
+      return;
+    }
+
+    if (role === 'admin') {
+      const ok = await ensureSuperAdmin(caller.uid, res);
+      if (!ok) return;
+    } else {
+      const allowed = await canManageFacultyIn(caller.uid, deptId);
+      if (!allowed) {
+        res.status(403).json({ message: 'Forbidden' });
+        return;
+      }
+    }
+
+    const next = await applyRoleWrite(uid, (existing) =>
+      withoutEntry(existing, deptId, role)
+    );
+    res.status(200).json({ uid, roles: next });
+  } catch (error) {
+    console.error('revokeRole failed:', error);
+    fail(res, 'Error revoking role', 500);
+  }
+});
+
+// promoteSuperAdmin — grant super admin to a user. Only a current super admin
+// may call this. The first super admin is seeded via a one-time admin SDK
+// script (see src/scripts/bootstrapSuperAdmin.ts); no web-callable bootstrap.
+export const promoteSuperAdmin = functions.https.onRequest(async (req, res) => {
+  setCors(req, res);
+  if (!handleMethod(req, res)) return;
+
+  const caller = await verifyAuth(req, res);
+  if (!caller) return;
+  const ok = await ensureSuperAdmin(caller.uid, res);
+  if (!ok) return;
+
+  try {
+    const body = asRecord(req.body);
+    const uid = readString(body, 'uid');
+    if (!uid) {
+      fail(res, 'Missing uid');
+      return;
+    }
+
+    // Confirm the target user exists in Auth before stamping the flag.
+    try {
+      await auth.getUser(uid);
+    } catch (err) {
+      fail(res, 'Target user does not exist', 404);
+      return;
+    }
+
+    await db.collection('users').doc(uid).set(
+      {
+        superAdmin: true,
+        superAdminAt: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+
+    res.status(200).json({ uid, superAdmin: true });
+  } catch (error) {
+    console.error('promoteSuperAdmin failed:', error);
+    fail(res, 'Error promoting super admin', 500);
+  }
+});
+
+// demoteSuperAdmin — inverse of promoteSuperAdmin. Only callable by another
+// super admin; callers cannot demote themselves (invariant: at least one
+// super admin must exist at all times).
+export const demoteSuperAdmin = functions.https.onRequest(async (req, res) => {
+  setCors(req, res);
+  if (!handleMethod(req, res)) return;
+
+  const caller = await verifyAuth(req, res);
+  if (!caller) return;
+  const ok = await ensureSuperAdmin(caller.uid, res);
+  if (!ok) return;
+
+  try {
+    const body = asRecord(req.body);
+    const uid = readString(body, 'uid');
+    if (!uid) {
+      fail(res, 'Missing uid');
+      return;
+    }
+
+    if (uid === caller.uid) {
+      fail(
+        res,
+        'A super admin cannot demote themselves. Ask another super admin.',
+        400
+      );
+      return;
+    }
+
+    // Refuse to demote the last super admin.
+    const remaining = await db
+      .collection('users')
+      .where('superAdmin', '==', true)
+      .limit(2)
+      .get();
+    if (remaining.size < 2) {
+      fail(res, 'Cannot demote the last super admin.', 409);
+      return;
+    }
+
+    await db.collection('users').doc(uid).set(
+      {
+        superAdmin: false,
+        superAdminDemotedAt: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+
+    res.status(200).json({ uid, superAdmin: false });
+  } catch (error) {
+    console.error('demoteSuperAdmin failed:', error);
+    fail(res, 'Error demoting super admin', 500);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "migrate:applications": "ts-node src/scripts/migrateApplications.ts",
     "migrate:applications:dry": "ts-node src/scripts/migrateApplications.ts --dry",
     "cleanup:nested-apps": "ts-node src/scripts/cleanupNestedApplications.ts",
-    "cleanup:nested-apps:execute": "ts-node src/scripts/cleanupNestedApplications.ts --execute"
+    "cleanup:nested-apps:execute": "ts-node src/scripts/cleanupNestedApplications.ts --execute",
+    "seed:departments:dry": "ts-node src/scripts/seedDepartments.ts",
+    "seed:departments": "ts-node src/scripts/seedDepartments.ts --execute",
+    "bootstrap:super-admin:dry": "ts-node src/scripts/bootstrapSuperAdmin.ts",
+    "bootstrap:super-admin": "ts-node src/scripts/bootstrapSuperAdmin.ts --execute"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/src/firebase/auth/auth_context.js
+++ b/src/firebase/auth/auth_context.js
@@ -10,6 +10,7 @@ import React, {
 import { useRouter, usePathname } from 'next/navigation';
 import firebase from '../firebase_config';
 import { isE2EMode, getE2EUser } from '@/utils/featureFlags';
+import { callFunction } from '@/firebase/functions/callFunction';
 
 const AuthContext = createContext();
 
@@ -18,6 +19,7 @@ export function useAuth() {
 }
 
 const LOGIN_RECORDED_KEY = 'cc_login_recorded_uid';
+const MATERIALIZE_KEY = 'cc_materialize_pending_uid';
 
 async function recordLoginOnce(user) {
   if (!user || typeof window === 'undefined') return;
@@ -48,6 +50,22 @@ async function recordLoginOnce(user) {
   }
 }
 
+// Unit 4 of multi-department support: resolve any pending-memberships invite
+// for this user's email on first sign-in of the session. Idempotent server-
+// side; the sessionStorage guard just avoids hitting the Cloud Function
+// every page navigation. Failure here is non-fatal — the user is still
+// signed in; next session retries.
+async function materializePendingOnce(user) {
+  if (!user || typeof window === 'undefined') return;
+  try {
+    if (sessionStorage.getItem(MATERIALIZE_KEY) === user.uid) return;
+    sessionStorage.setItem(MATERIALIZE_KEY, user.uid);
+    await callFunction('materializePendingMemberships', {});
+  } catch (err) {
+    console.error('Failed to materialize pending memberships:', err);
+  }
+}
+
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -66,7 +84,10 @@ export function AuthProvider({ children }) {
     const unsubscribe = auth.onAuthStateChanged((user) => {
       setUser(user);
       setLoading(false);
-      if (user) recordLoginOnce(user);
+      if (user) {
+        recordLoginOnce(user);
+        materializePendingOnce(user);
+      }
 
       if (
         !user &&

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,0 +1,148 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import firebase from '@/firebase/firebase_config';
+import 'firebase/firestore';
+import { useAuth } from '@/firebase/auth/auth_context';
+
+// Unified identity hook — introduced in Unit 3 of multi-department support.
+// Replaces the scattered `useAuth() + GetUserRole()` pattern with a single
+// subscription that returns Firebase Auth user, legacy role/department (still
+// dual-written), and the new per-dept roles model.
+//
+// During the transition window, consumers should prefer:
+//   - `superAdmin` for the super-admin-only gate
+//   - `adminOfDepartmentIds` / `facultyOfDepartmentIds` / `departmentIds` for
+//     department-scoped decisions
+//   - `legacyRole` only where migration has not yet touched a call site; this
+//     field is dropped in the cleanup PR after Unit 7.
+
+export type PerDeptRole = 'admin' | 'faculty';
+
+export interface CurrentUserRoleEntry {
+  deptId: string;
+  role: PerDeptRole;
+}
+
+export interface CurrentUser {
+  firebaseUser: firebase.User | null;
+  superAdmin: boolean;
+  roles: CurrentUserRoleEntry[];
+  adminOfDepartmentIds: string[];
+  facultyOfDepartmentIds: string[];
+  departmentIds: string[];
+  activeDeptId: string | null; // the single admin dept if any; null for faculty-only / super-only
+  // Legacy fields — read during transition; dropped in cleanup PR.
+  legacyRole: string;
+  legacyDepartment: string;
+}
+
+export interface UseCurrentUserResult {
+  user: CurrentUser;
+  loading: boolean;
+  error: Error | null;
+}
+
+const EMPTY: CurrentUser = {
+  firebaseUser: null,
+  superAdmin: false,
+  roles: [],
+  adminOfDepartmentIds: [],
+  facultyOfDepartmentIds: [],
+  departmentIds: [],
+  activeDeptId: null,
+  legacyRole: '',
+  legacyDepartment: '',
+};
+
+function sanitizeStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string');
+}
+
+function sanitizeRoles(v: unknown): CurrentUserRoleEntry[] {
+  if (!Array.isArray(v)) return [];
+  const out: CurrentUserRoleEntry[] = [];
+  for (const entry of v) {
+    if (!entry || typeof entry !== 'object') continue;
+    const rec = entry as Record<string, unknown>;
+    const deptId = typeof rec.deptId === 'string' ? rec.deptId : null;
+    const role =
+      rec.role === 'admin' || rec.role === 'faculty'
+        ? (rec.role as PerDeptRole)
+        : null;
+    if (deptId && role) out.push({ deptId, role });
+  }
+  return out;
+}
+
+export function useCurrentUser(): UseCurrentUserResult {
+  const { user: firebaseUser } = useAuth();
+  const [docData, setDocData] = useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!firebaseUser?.uid) {
+      setDocData(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    const unsub = firebase
+      .firestore()
+      .collection('users')
+      .doc(firebaseUser.uid)
+      .onSnapshot(
+        (snap) => {
+          setDocData((snap.data() as Record<string, unknown>) ?? null);
+          setLoading(false);
+        },
+        (err) => {
+          console.error('useCurrentUser listener error:', err);
+          setError(err);
+          setLoading(false);
+        }
+      );
+    return () => unsub();
+  }, [firebaseUser?.uid]);
+
+  const current = useMemo<CurrentUser>(() => {
+    if (!firebaseUser || !docData) {
+      return { ...EMPTY, firebaseUser };
+    }
+
+    const roles = sanitizeRoles(docData.roles);
+    const adminOfDepartmentIds = sanitizeStringArray(
+      docData.adminOfDepartmentIds
+    );
+    const facultyOfDepartmentIds = sanitizeStringArray(
+      docData.facultyOfDepartmentIds
+    );
+    const departmentIds = sanitizeStringArray(docData.departmentIds);
+
+    return {
+      firebaseUser,
+      superAdmin: docData.superAdmin === true,
+      roles,
+      adminOfDepartmentIds,
+      facultyOfDepartmentIds,
+      departmentIds:
+        departmentIds.length > 0
+          ? departmentIds
+          : Array.from(
+              new Set([...adminOfDepartmentIds, ...facultyOfDepartmentIds])
+            ),
+      activeDeptId: adminOfDepartmentIds[0] ?? null,
+      legacyRole:
+        typeof docData.role === 'string' ? (docData.role as string) : '',
+      legacyDepartment:
+        typeof docData.department === 'string'
+          ? (docData.department as string)
+          : '',
+    };
+  }, [firebaseUser, docData]);
+
+  return { user: current, loading, error };
+}

--- a/src/hooks/useDepartments.ts
+++ b/src/hooks/useDepartments.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import firebase from '@/firebase/firebase_config';
+import 'firebase/firestore';
+import { Department, DepartmentStatus } from '@/types/department';
+
+function toDate(v: any): Date | null {
+  if (!v) return null;
+  if (v instanceof Date) return v;
+  if (typeof v.toDate === 'function') return v.toDate();
+  return null;
+}
+
+function mapDoc(doc: firebase.firestore.QueryDocumentSnapshot): Department {
+  const d = doc.data() as any;
+  const status: DepartmentStatus =
+    d.status === 'archived' ? 'archived' : 'active';
+  return {
+    id: doc.id,
+    code: typeof d.code === 'string' ? d.code : '',
+    name: typeof d.name === 'string' ? d.name : '',
+    status,
+    createdAt: toDate(d.createdAt),
+    archivedAt: toDate(d.archivedAt),
+  };
+}
+
+type UseDepartmentsOptions = {
+  // 'active' (default) hides archived. 'all' returns both.
+  include?: 'active' | 'all';
+};
+
+type UseDepartmentsResult = {
+  departments: Department[];
+  byId: Map<string, Department>;
+  loading: boolean;
+  error: Error | null;
+};
+
+// Subscribes to the departments collection and returns a hydrated list.
+// Client reads are permitted for any authenticated user under the Unit 1
+// baseline rules; Unit 7 will tighten reads if needed.
+export function useDepartments(
+  options: UseDepartmentsOptions = {}
+): UseDepartmentsResult {
+  const include = options.include ?? 'active';
+  const [all, setAll] = useState<Department[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    const col = firebase.firestore().collection('departments');
+    const unsub = col.orderBy('code').onSnapshot(
+      (snap) => {
+        setAll(snap.docs.map(mapDoc));
+        setLoading(false);
+      },
+      (err) => {
+        console.error('useDepartments listener error:', err);
+        setError(err);
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, []);
+
+  const departments = useMemo(() => {
+    if (include === 'all') return all;
+    return all.filter((d) => d.status === 'active');
+  }, [all, include]);
+
+  const byId = useMemo(() => {
+    const m = new Map<string, Department>();
+    for (const d of all) m.set(d.id, d);
+    return m;
+  }, [all]);
+
+  return { departments, byId, loading, error };
+}
+
+// Convenience lookup that avoids a subscription when the caller only needs to
+// resolve an id once and already has the hydrated list.
+export function findDepartmentById(
+  departments: Department[],
+  id: string | null | undefined
+): Department | null {
+  if (!id) return null;
+  return departments.find((d) => d.id === id) ?? null;
+}

--- a/src/scripts/bootstrapSuperAdmin.ts
+++ b/src/scripts/bootstrapSuperAdmin.ts
@@ -1,0 +1,81 @@
+/**
+ * Bootstrap the first super admin for Course Connect.
+ *
+ * This is the one-time admin-SDK path documented in Unit 3 of the multi-dept
+ * plan. After the first super admin exists, further promotions go through the
+ * `promoteSuperAdmin` Cloud Function (which is gated by the existing super
+ * admin). This script is NOT a web-callable endpoint — it must run locally
+ * with service-account credentials.
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=./serviceAccountKey.json \
+ *     npx ts-node src/scripts/bootstrapSuperAdmin.ts --email=you@ufl.edu
+ *
+ *   Add --execute to actually write; without it, dry-run only.
+ */
+
+const admin = require('firebase-admin');
+
+function getArg(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const hit = process.argv.find((v) => v.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : undefined;
+}
+
+const EMAIL = getArg('email');
+const DRY = !process.argv.includes('--execute');
+
+function init() {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault(),
+      projectId: 'courseconnect-c6a7b',
+    });
+  }
+  return { db: admin.firestore(), auth: admin.auth() };
+}
+
+async function main() {
+  if (!EMAIL) {
+    console.error('Missing --email=<user@ufl.edu>');
+    process.exit(2);
+  }
+
+  const { db, auth } = init();
+
+  let user;
+  try {
+    user = await auth.getUserByEmail(EMAIL);
+  } catch (err) {
+    console.error(
+      `No Firebase Auth user found for ${EMAIL}. Sign in once via the app before running this.`
+    );
+    process.exit(3);
+  }
+
+  console.log(
+    `${
+      DRY ? '[DRY RUN]' : '[EXECUTE]'
+    } Bootstrap super admin for ${EMAIL} (uid=${user.uid})`
+  );
+
+  if (DRY) {
+    console.log('Dry run only — re-run with --execute to apply.');
+    return;
+  }
+
+  await db.collection('users').doc(user.uid).set(
+    {
+      superAdmin: true,
+      superAdminAt: admin.firestore.FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  console.log(`✓ users/${user.uid}.superAdmin = true`);
+}
+
+main().catch((err) => {
+  console.error('bootstrapSuperAdmin failed:', err);
+  process.exit(1);
+});

--- a/src/scripts/seedDepartments.ts
+++ b/src/scripts/seedDepartments.ts
@@ -1,0 +1,101 @@
+/**
+ * Seed the three initial Course Connect departments (ECE, CISE, MAE).
+ *
+ * Part of Unit 2 of the multi-department support plan. Idempotent — re-running
+ * skips docs that already exist.
+ *
+ * Usage:
+ *   npm run seed:departments:dry        # prints intended writes
+ *   npm run seed:departments -- --execute
+ *
+ * Requires GOOGLE_APPLICATION_CREDENTIALS to point to a service account key
+ * with Firestore write access (same as migrateApplications.ts).
+ *
+ * Co-located with other scripts in src/scripts/ so the existing npm-script
+ * pattern works. The multi-dept plan originally proposed functions/src/migrations/
+ * but the ts-node entry point sits cleaner here.
+ */
+
+const admin = require('firebase-admin');
+
+const DRY = !process.argv.includes('--execute');
+
+type SeedEntry = {
+  id: string;
+  code: string;
+  name: string;
+};
+
+// Canonical names match src/constants/research.ts so UI lookups continue to
+// work during the transition. These three are the only departments that today
+// have live user data.
+const SEED: SeedEntry[] = [
+  { id: 'ece', code: 'ECE', name: 'Electrical and Computer Engineering' },
+  {
+    id: 'cise',
+    code: 'CISE',
+    name: 'Computer and Information Sciences and Engineering',
+  },
+  { id: 'mae', code: 'MAE', name: 'Mechanical and Aerospace Engineering' },
+];
+
+function init() {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault(),
+      projectId: 'courseconnect-c6a7b',
+    });
+  }
+  return admin.firestore();
+}
+
+async function main() {
+  const db = init();
+  const col = db.collection('departments');
+
+  console.log(DRY ? '[DRY RUN] Preview:' : '[EXECUTE] Writing:');
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const entry of SEED) {
+    const ref = col.doc(entry.id);
+    const snap = await ref.get();
+
+    if (snap.exists) {
+      console.log(`  skip  ${entry.id} (already exists)`);
+      skipped += 1;
+      continue;
+    }
+
+    console.log(
+      `  create  ${entry.id}  code=${entry.code}  name="${entry.name}"`
+    );
+    created += 1;
+
+    if (!DRY) {
+      await ref.set({
+        id: entry.id,
+        code: entry.code,
+        name: entry.name,
+        status: 'active',
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    }
+  }
+
+  console.log('');
+  console.log(
+    `Summary: ${created} to create, ${skipped} skipped (already existed).`
+  );
+  if (DRY) {
+    console.log('Dry run only — re-run with --execute to apply.');
+  } else {
+    console.log('Writes applied.');
+  }
+}
+
+main().catch((err) => {
+  console.error('seedDepartments failed:', err);
+  process.exit(1);
+});

--- a/src/types/department.ts
+++ b/src/types/department.ts
@@ -1,0 +1,13 @@
+// Department entity — introduced in Unit 2 of multi-department support.
+// Source of truth is the `departments/{id}` Firestore collection.
+
+export type DepartmentStatus = 'active' | 'archived';
+
+export interface Department {
+  id: string; // deterministic slug of code, e.g. 'ece'
+  code: string; // uppercase short code, e.g. 'ECE' (2–6 chars)
+  name: string; // human-readable name
+  status: DepartmentStatus;
+  createdAt?: Date | null;
+  archivedAt?: Date | null;
+}


### PR DESCRIPTION
…pipeline

Lands Units 2-4 of the multi-department support plan (docs/plans/2026-04-18-002-feat-multi-department-support-plan.md).

Department entity (Unit 2)
- departments/{id} Firestore entity with active|archived status
- createDepartment / updateDepartment / archiveDepartment / unarchiveDepartment Cloud Functions, super-admin gated
- useDepartments hook + Department type
- seed:departments script for ECE/CISE/MAE

Role storage (Unit 3)
- users/{uid}.roles[]: single-array role model (admin and faculty per-department; student and unapproved stay global)
- Denormalized adminOfDepartmentIds, facultyOfDepartmentIds, departmentIds on the user doc for cheap rule checks
- setRole / revokeRole / promoteSuperAdmin / demoteSuperAdmin Cloud Functions with single-admin-per-user enforcement
- useCurrentUser hook unifying auth + role reads (replaces the scattered useAuth() + GetUserRole() pattern going forward; legacy role/department remain dual-written until the cleanup PR)
- bootstrap:super-admin script for the one-time first-super-admin seed

Pending-memberships invites (Unit 4)
- pendingMemberships/{email} Firestore records resolved on first sign-in; no signed tokens, no TTL, no oobCode races
- createPendingMembership / revokePendingMembership / materializePendingMemberships Cloud Functions
- sendInviteNotificationEmail template
- auth_context materializes pending invites once per session

Security rules
- departments/: any authed read, writes server-only
- pendingMemberships/: invitee can read their own, admins can read, writes server-only
- login_events/: append-only; no client reads

Shared HTTP helpers (setCors, handleMethod, verifyAuth, asRecord, readString, fail, getRole, ensureSuperAdmin, db, auth) are now exported from functions/src/index.ts so roles.ts, departments.ts, and invites.ts consume them without re-initializing the SDK.