### PR TITLE
feat(course-fetch): admin-editable, scheduled UF course scraper pipeline

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": ["next/core-web-vitals", "prettier"]
 }

--- a/docs/course-fetch-pipeline.md
+++ b/docs/course-fetch-pipeline.md
@@ -1,0 +1,137 @@
+# Course Fetch Pipeline
+
+Admin-editable, periodically running pipeline that replaces the standalone
+course-scraper script. All runtime code lives inside the existing app —
+Cloud Functions do the work, Firestore stores results, and the Next.js admin
+UI edits configs.
+
+## What's in this feature
+
+| Layer                       | Path                                            |
+| --------------------------- | ----------------------------------------------- |
+| Shared types (frontend)     | `src/types/courseFetch.ts`                      |
+| Frontend API client         | `src/hooks/useCourseFetch.ts`                   |
+| Admin UI                    | `src/app/admin-course-fetch/*`                  |
+| Scraper service             | `functions/src/courseFetcher/*`                 |
+| UF provider                 | `functions/src/courseFetcher/providers/uf.ts`   |
+| HTTPS + scheduled endpoints | `functions/src/courseFetch.ts`                  |
+| Firestore rules             | `firestore.rules` (course-fetch block)          |
+| Firestore indexes           | `firestore.indexes.json` (course-fetch entries) |
+| Tests                       | `functions/src/courseFetcher/__tests__/*`       |
+
+## Data model
+
+Four Firestore collections:
+
+- `courseFetchConfigs/{id}` — admin-managed configs (label, provider, term,
+  year, departments, filters, refresh cadence, enabled, status fields).
+- `courseFetchConfigs/{id}/runs/{runId}` — one document per fetch attempt
+  with status, counts, errors, warnings, and duration.
+- `catalog/{courseId}` — normalized scraped courses. Doc id shape is
+  `PROVIDER:termCode:CODE`, e.g. `UF:2268:COP3502`.
+- `catalog/{courseId}/sections/{sectionId}` — sections under each course.
+  Doc id shape is `PROVIDER:termCode:classNumber`, e.g. `UF:2268:11111`.
+
+These collections are separate from the existing `semesters/{name}/courses`
+collection used by the Excel-upload flow — no existing data is touched.
+
+Rules: configs and runs are admin-only read; catalog collections are
+readable by any authed user. All writes go through Cloud Functions using
+the admin SDK, so client writes are denied.
+
+Indexes: `courseFetchConfigs(enabled, nextRefreshAt)` for the scheduler,
+`runs(configId, startedAt desc)` for history, `catalog(provider, termCode,
+department, code)` for catalog queries, and a collection-group index on
+`sections(termCode, courseCode, classNumber)`.
+
+## How to add a new course-fetch config
+
+1. Sign in as an admin.
+2. Open **Course Fetch** in the admin sidebar (or navigate to
+   `/admin-course-fetch`).
+3. Click **New config**, fill in at minimum:
+   - **Label** — e.g. `UF Spring CISE + Math`
+   - **Provider** — `UF` (only option today)
+   - **Term** + **Year** — e.g. `spring 2026`
+   - **Departments** (optional) — comma-separated uppercase codes,
+     e.g. `CISE, MATH`
+   - **Code prefixes** (optional) — e.g. `COP, EEL, MAC`
+   - **Refresh** — `Manual only`, `Hourly`, `Daily`, `Weekly`, or
+     `Every N hours`
+   - **Enabled** — leave off until you've run it once manually
+4. Save, click the ▶ **Run now** action, and watch the status chip update.
+   Use the 🕒 history button to inspect per-run details.
+
+## How scheduled refresh works
+
+`scheduledCourseFetchRefresh` (Firebase scheduled function) runs every 30
+minutes:
+
+1. Load all `courseFetchConfigs` where `enabled == true`.
+2. Keep those whose `nextRefreshAt` is unset or `≤ now`.
+3. For each, atomically claim a 10-minute `runLeaseUntil` lease in a
+   Firestore transaction. A second scheduler firing during the same window
+   will see the active lease and skip.
+4. Run the same `runAndPersist()` the manual trigger uses. On completion,
+   update `lastStatus`, `lastError`, `lastSuccessAt`, and push
+   `nextRefreshAt` forward by the configured interval.
+
+The job is idempotent: rerunning it either no-ops (lease held) or
+reprocesses the same config, writing the same doc ids with `merge: true`.
+
+## How to add a new school / data provider
+
+1. Create `functions/src/courseFetcher/providers/<name>.ts` that exports
+   a `Provider` (`id`, `resolveTermCode`, `fetch`). Keep all provider-
+   specific transport and shape logic inside this file.
+2. Register it in the `PROVIDERS` map in `functions/src/courseFetcher/pipeline.ts`.
+3. Extend the `ProviderId` union in `functions/src/courseFetcher/types.ts`
+   and `src/types/courseFetch.ts`.
+4. Add the new ID to the allowed providers list in
+   `functions/src/courseFetcher/validation.ts`.
+5. Add provider-specific options to the admin form if needed.
+
+## UF provider specifics
+
+Modeled directly on `UFCourseGrabber.py` (in the repo root):
+
+- Endpoint: `https://one.uf.edu/apix/soc/schedule/?category=RES&term=<code>&last-control-number=<n>`.
+- Term code: `"2" + last-2-of-year + termDigit` where `spring=1, summer=5, fall=8`. Fall 2026 → `2268`.
+- Pagination: N parallel workers (N = `concurrency`, 1–16). Worker `i` walks `last-control-number = 50*i, 50*i + 50*N, 50*i + 100*N, …` and stops when its response reports `RETRIEVEDROWS == 0`.
+- The endpoint does not accept department or course-code query params, so admin-configured filters are applied post-normalization.
+- Section-level metadata fields from the original Python cleaner (`EEP`, `LMS`, `acadCareer`, `addEligible`, `dNote`) are never promoted into the normalized shape, so there's nothing to delete.
+- Meeting times are read from `meetTimeBegin` / `meetTimeEnd` (12h `H:MM AM/PM`) and normalized to 24h `HH:MM` when possible; otherwise the raw value is retained.
+
+## Security notes
+
+- No session cookies or API keys are hardcoded. The original Python scraper
+  embedded `ONEUF_SESSION` values in source; those have been removed from
+  the new pipeline. If UF's endpoint ever requires a cookie, the UF provider
+  reads it from `process.env.ONE_UF_COOKIE` at runtime only.
+- Admin-only Cloud Functions check `users/{uid}.role === 'admin'` after
+  verifying the bearer token. Faculty cannot edit configs.
+- Inputs are validated against a strict allowlist (provider enum, term
+  enum, regex for department codes and course prefixes, numeric ranges).
+  The admin UI does not supply URLs or arbitrary provider parameters —
+  the UF provider constructs trusted `https://one.uf.edu/apix/soc/schedule`
+  URLs internally.
+- The scraper never logs request headers or cookies. Errors only include
+  the status code and message.
+
+## Tests
+
+Pure-logic tests (no Firebase credentials required) live at
+`functions/src/courseFetcher/__tests__/pipeline.test.ts` and run via Node's
+built-in test runner:
+
+```
+cd functions
+npm install
+npm test
+```
+
+They cover: term-code mapping, code-space insertion, 24h time
+normalization, filter logic, deduplication, course/section finalization,
+config validation (including bad inputs), next-refresh computation, and an
+end-to-end pipeline run against a stubbed fetcher (success, total-failure,
+and non-JSON response paths).

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -61,6 +61,41 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "courseFetchConfigs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "enabled", "order": "ASCENDING" },
+        { "fieldPath": "nextRefreshAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "configId", "order": "ASCENDING" },
+        { "fieldPath": "startedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "catalog",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "provider", "order": "ASCENDING" },
+        { "fieldPath": "termCode", "order": "ASCENDING" },
+        { "fieldPath": "department", "order": "ASCENDING" },
+        { "fieldPath": "code", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "sections",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "termCode", "order": "ASCENDING" },
+        { "fieldPath": "courseCode", "order": "ASCENDING" },
+        { "fieldPath": "classNumber", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -168,6 +168,34 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // --------- course-fetch pipeline ---------
+    // Configs and per-run history live under `courseFetchConfigs`. All writes
+    // (including scheduled runs) go through Cloud Functions using the admin
+    // SDK, which bypasses rules. Client reads are admin-only; direct client
+    // writes are denied as defense-in-depth.
+    match /courseFetchConfigs/{configId} {
+      allow read: if isAdmin();
+      allow write: if false;
+
+      match /runs/{runId} {
+        allow read: if isAdmin();
+        allow write: if false;
+      }
+    }
+
+    // Normalized scraped catalog. Any authed user may read so it can drive
+    // pickers and future student/faculty features; writes go through Cloud
+    // Functions only.
+    match /catalog/{courseId} {
+      allow read: if isAuthed();
+      allow write: if false;
+
+      match /sections/{sectionId} {
+        allow read: if isAuthed();
+        allow write: if false;
+      }
+    }
+
     // --------- login events (audit trail; writes only) ---------
     // auth_context.js appends a row on first sign-in per session. No one
     // reads these from the client today.

--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,8 @@
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "test": "npm run build && node --test lib/courseFetcher/__tests__/"
   },
   "engines": {
     "node": "20"

--- a/functions/src/courseFetch.ts
+++ b/functions/src/courseFetch.ts
@@ -1,0 +1,379 @@
+// Course-fetch HTTP endpoints + scheduled refresh.
+//
+// All HTTPS endpoints follow the existing project convention: POST-only JSON,
+// bearer-token auth via verifyAuth, admin-only via an inline role check.
+
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import type { Request, Response } from 'express';
+import {
+  asRecord,
+  db,
+  fail,
+  getRole,
+  handleMethod,
+  readString,
+  setCors,
+  verifyAuth,
+} from './index';
+import { runAndPersist } from './courseFetcher/runner';
+import {
+  computeNextRefreshAt,
+  validateConfigInput,
+  type ValidatedConfig,
+} from './courseFetcher/validation';
+
+async function ensureAdmin(uid: string, res: Response): Promise<boolean> {
+  const role = await getRole(uid);
+  if (role !== 'admin') {
+    res.status(403).json({ message: 'Forbidden — admin only' });
+    return false;
+  }
+  return true;
+}
+
+function now(): FirebaseFirestore.FieldValue {
+  return admin.firestore.FieldValue.serverTimestamp();
+}
+
+function configFromDoc(
+  snap: FirebaseFirestore.DocumentSnapshot
+): Record<string, unknown> | null {
+  if (!snap.exists) return null;
+  const data = snap.data() ?? {};
+  return { id: snap.id, ...data };
+}
+
+// --- CRUD ---
+
+export const listCourseFetchConfigs = functions.https.onRequest(
+  async (req: Request, res: Response) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+    if (!(await ensureAdmin(caller.uid, res))) return;
+
+    try {
+      const snap = await db
+        .collection('courseFetchConfigs')
+        .orderBy('createdAt', 'desc')
+        .limit(200)
+        .get();
+      const configs = snap.docs.map((d) => configFromDoc(d)).filter(Boolean);
+      res.status(200).json({ configs });
+    } catch (error) {
+      console.error('listCourseFetchConfigs failed:', error);
+      fail(res, 'Failed to list configs', 500);
+    }
+  }
+);
+
+export const createCourseFetchConfig = functions.https.onRequest(
+  async (req: Request, res: Response) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+    if (!(await ensureAdmin(caller.uid, res))) return;
+
+    try {
+      const body = asRecord(req.body);
+      const result = validateConfigInput(body);
+      if (!result.ok) {
+        res
+          .status(400)
+          .json({ message: 'Invalid config', errors: result.errors });
+        return;
+      }
+      const v = result.value;
+      const nowDate = new Date();
+      const nextRefreshAt = v.enabled
+        ? computeNextRefreshAt(v.refresh, nowDate)
+        : null;
+      const ref = db.collection('courseFetchConfigs').doc();
+      await ref.set({
+        id: ref.id,
+        ...v,
+        lastStatus: 'idle',
+        nextRefreshAt,
+        createdAt: now(),
+        updatedAt: now(),
+        createdBy: caller.uid,
+        updatedBy: caller.uid,
+      });
+      res.status(200).json({ id: ref.id });
+    } catch (error) {
+      console.error('createCourseFetchConfig failed:', error);
+      fail(res, 'Failed to create config', 500);
+    }
+  }
+);
+
+export const updateCourseFetchConfig = functions.https.onRequest(
+  async (req: Request, res: Response) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+    if (!(await ensureAdmin(caller.uid, res))) return;
+
+    try {
+      const body = asRecord(req.body);
+      const id = readString(body, 'id');
+      if (!id) {
+        fail(res, 'Missing id');
+        return;
+      }
+      const ref = db.collection('courseFetchConfigs').doc(id);
+      const existing = await ref.get();
+      if (!existing.exists) {
+        fail(res, 'Config not found', 404);
+        return;
+      }
+      const result = validateConfigInput(body);
+      if (!result.ok) {
+        res
+          .status(400)
+          .json({ message: 'Invalid config', errors: result.errors });
+        return;
+      }
+      const v = result.value;
+      const nowDate = new Date();
+      const nextRefreshAt = v.enabled
+        ? computeNextRefreshAt(v.refresh, nowDate)
+        : null;
+      await ref.set(
+        {
+          ...v,
+          nextRefreshAt,
+          updatedAt: now(),
+          updatedBy: caller.uid,
+        },
+        { merge: true }
+      );
+      res.status(200).json({ id });
+    } catch (error) {
+      console.error('updateCourseFetchConfig failed:', error);
+      fail(res, 'Failed to update config', 500);
+    }
+  }
+);
+
+export const deleteCourseFetchConfig = functions.https.onRequest(
+  async (req: Request, res: Response) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+    if (!(await ensureAdmin(caller.uid, res))) return;
+
+    try {
+      const body = asRecord(req.body);
+      const id = readString(body, 'id');
+      if (!id) {
+        fail(res, 'Missing id');
+        return;
+      }
+      // Delete all run records first (in small pages), then the config. We
+      // leave catalog docs in place — other configs may also source them.
+      const runsCol = db
+        .collection('courseFetchConfigs')
+        .doc(id)
+        .collection('runs');
+      while (true) {
+        const page = await runsCol.limit(200).get();
+        if (page.empty) break;
+        const batch = db.batch();
+        page.docs.forEach((d) => batch.delete(d.ref));
+        await batch.commit();
+      }
+      await db.collection('courseFetchConfigs').doc(id).delete();
+      res.status(200).json({ id, deleted: true });
+    } catch (error) {
+      console.error('deleteCourseFetchConfig failed:', error);
+      fail(res, 'Failed to delete config', 500);
+    }
+  }
+);
+
+// --- Manual trigger ---
+
+async function loadValidatedConfig(
+  id: string
+): Promise<{
+  config: ValidatedConfig;
+  doc: FirebaseFirestore.DocumentSnapshot;
+} | null> {
+  const snap = await db.collection('courseFetchConfigs').doc(id).get();
+  if (!snap.exists) return null;
+  const input = snap.data() ?? {};
+  const result = validateConfigInput(input as Record<string, unknown>);
+  if (!result.ok) return null;
+  return { config: result.value, doc: snap };
+}
+
+export const triggerCourseFetch = functions.https.onRequest(
+  async (req: Request, res: Response) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+    if (!(await ensureAdmin(caller.uid, res))) return;
+
+    try {
+      const body = asRecord(req.body);
+      const id = readString(body, 'id');
+      if (!id) {
+        fail(res, 'Missing id');
+        return;
+      }
+      const loaded = await loadValidatedConfig(id);
+      if (!loaded) {
+        fail(res, 'Config not found or invalid', 404);
+        return;
+      }
+      // Run synchronously. Cloud Functions v1 has a 540s timeout; a single
+      // config shouldn't exceed that. If it does we'll split into shards.
+      const outcome = await runAndPersist({
+        db,
+        configId: id,
+        config: loaded.config,
+        triggeredBy: 'manual',
+        triggeredByUid: caller.uid,
+      });
+      res.status(200).json(outcome);
+    } catch (error) {
+      console.error('triggerCourseFetch failed:', error);
+      fail(res, 'Failed to run fetch', 500);
+    }
+  }
+);
+
+// --- Run history ---
+
+export const listCourseFetchRuns = functions.https.onRequest(
+  async (req: Request, res: Response) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+    if (!(await ensureAdmin(caller.uid, res))) return;
+
+    try {
+      const body = asRecord(req.body);
+      const id = readString(body, 'id');
+      const limitRaw = Number(body.limit);
+      const limit = Number.isFinite(limitRaw)
+        ? Math.max(1, Math.min(100, limitRaw))
+        : 20;
+      if (!id) {
+        fail(res, 'Missing id');
+        return;
+      }
+      const snap = await db
+        .collection('courseFetchConfigs')
+        .doc(id)
+        .collection('runs')
+        .orderBy('startedAt', 'desc')
+        .limit(limit)
+        .get();
+      const runs = snap.docs.map((d) => ({ runId: d.id, ...d.data() }));
+      res.status(200).json({ runs });
+    } catch (error) {
+      console.error('listCourseFetchRuns failed:', error);
+      fail(res, 'Failed to list runs', 500);
+    }
+  }
+);
+
+// --- Scheduled refresh ---
+//
+// Runs every 30 minutes. Iterates enabled configs whose `nextRefreshAt` is
+// due. Idempotent via a lease field — two concurrent invocations won't both
+// run the same config because the second one's transaction sees the updated
+// lease and skips.
+
+export const scheduledCourseFetchRefresh = functions.pubsub
+  .schedule('every 30 minutes')
+  .onRun(async () => {
+    const nowDate = new Date();
+    const snap = await db
+      .collection('courseFetchConfigs')
+      .where('enabled', '==', true)
+      .get();
+    const candidates = snap.docs.filter((d) => {
+      const data = d.data();
+      const ref = data.nextRefreshAt;
+      // nextRefreshAt is a Firestore Timestamp when set server-side.
+      const dueAt =
+        ref && typeof ref.toDate === 'function' ? ref.toDate() : ref ?? null;
+      if (!dueAt) return true; // enabled but no schedule computed yet
+      return dueAt instanceof Date && dueAt.getTime() <= nowDate.getTime();
+    });
+
+    for (const doc of candidates) {
+      const id = doc.id;
+      const ref = db.collection('courseFetchConfigs').doc(id);
+      const token = `${nowDate.toISOString()}-${Math.random()
+        .toString(36)
+        .slice(2, 10)}`;
+
+      // Lease: skip if someone else claimed within the last 10 minutes.
+      const leased = await db.runTransaction(async (tx) => {
+        const latest = await tx.get(ref);
+        if (!latest.exists) return false;
+        const data = latest.data() as Record<string, unknown>;
+        const leaseUntil = data.runLeaseUntil;
+        const leaseDate =
+          leaseUntil &&
+          typeof (leaseUntil as { toDate?: unknown }).toDate === 'function'
+            ? (leaseUntil as { toDate: () => Date }).toDate()
+            : null;
+        if (leaseDate && leaseDate.getTime() > nowDate.getTime()) return false;
+        tx.set(
+          ref,
+          {
+            runLeaseUntil: new Date(nowDate.getTime() + 10 * 60 * 1000),
+            runLeaseToken: token,
+          },
+          { merge: true }
+        );
+        return true;
+      });
+      if (!leased) continue;
+
+      const loaded = await loadValidatedConfig(id);
+      if (!loaded) {
+        await ref.set(
+          {
+            lastStatus: 'failed',
+            lastError: 'config validation failed',
+            runLeaseUntil: admin.firestore.FieldValue.delete(),
+            runLeaseToken: admin.firestore.FieldValue.delete(),
+          },
+          { merge: true }
+        );
+        continue;
+      }
+      try {
+        await runAndPersist({
+          db,
+          configId: id,
+          config: loaded.config,
+          triggeredBy: 'scheduled',
+        });
+      } catch (err) {
+        console.error(`scheduled run ${id} failed:`, err);
+      } finally {
+        await ref.set(
+          {
+            runLeaseUntil: admin.firestore.FieldValue.delete(),
+            runLeaseToken: admin.firestore.FieldValue.delete(),
+          },
+          { merge: true }
+        );
+      }
+    }
+    return null;
+  });

--- a/functions/src/courseFetcher/__tests__/pipeline.test.ts
+++ b/functions/src/courseFetcher/__tests__/pipeline.test.ts
@@ -1,0 +1,397 @@
+// Unit tests for the pure pipeline helpers and the UF provider.
+//
+// Run via Node's built-in test runner — no new dep. From the functions/ dir:
+//   npx tsc --noEmit
+//   node --test --import ts-node/esm src/courseFetcher/__tests__/*.test.ts
+// or compile to lib/ first and run `node --test lib/courseFetcher/__tests__`.
+//
+// (firebase-admin is never imported here, so these tests don't need
+// credentials.)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  addCodeSpace,
+  departmentFromCode,
+  to24h,
+  filterCourse,
+  dedupCourses,
+  dedupSections,
+  finalizeCourse,
+  finalizeSection,
+  courseKey,
+} from '../normalize';
+import { ufTermCode } from '../providers/uf';
+import { fetchCoursesForConfig } from '../pipeline';
+import { validateConfigInput, computeNextRefreshAt } from '../validation';
+import type { Fetcher, NormalizedCourse } from '../types';
+
+// --- normalize.addCodeSpace ---
+
+test('addCodeSpace inserts a space between letters and digits', () => {
+  assert.equal(addCodeSpace('COP3502'), 'COP 3502');
+  assert.equal(addCodeSpace('EEL4924C'), 'EEL 4924C');
+});
+
+test('addCodeSpace leaves already-spaced or unknown codes alone', () => {
+  assert.equal(addCodeSpace('COP 3502'), 'COP 3502');
+  assert.equal(addCodeSpace(''), '');
+  assert.equal(addCodeSpace('weird!'), 'weird!');
+});
+
+// --- normalize.departmentFromCode ---
+
+test('departmentFromCode returns the leading alphabetic prefix', () => {
+  assert.equal(departmentFromCode('COP3502'), 'COP');
+  assert.equal(departmentFromCode('MAC2311'), 'MAC');
+  assert.equal(departmentFromCode(''), '');
+});
+
+// --- normalize.to24h ---
+
+test('to24h handles 24h, 12h, and military formats', () => {
+  assert.equal(to24h('08:30'), '08:30');
+  assert.equal(to24h('12:50 pm'), '12:50');
+  assert.equal(to24h('1:00am'), '01:00');
+  assert.equal(to24h('1250'), '12:50');
+  assert.equal(to24h('0830'), '08:30');
+});
+
+test('to24h returns undefined on nonsense input', () => {
+  assert.equal(to24h('period 3'), undefined);
+  assert.equal(to24h(''), undefined);
+  assert.equal(to24h(undefined), undefined);
+});
+
+// --- filter / dedup ---
+
+function course(
+  code: string,
+  extra: Partial<NormalizedCourse> = {}
+): NormalizedCourse {
+  return {
+    code,
+    codeWithSpace: code,
+    title: code,
+    ...extra,
+  };
+}
+
+test('filterCourse respects code prefix and department filters', () => {
+  const cop = course('COP3502', { department: 'CISE' });
+  const cda = course('CDA3101', { department: 'CISE' });
+  const mac = course('MAC2311', { department: 'MATH' });
+  assert.equal(filterCourse(cop, { codePrefixes: ['COP'] }), true);
+  assert.equal(filterCourse(cda, { codePrefixes: ['COP'] }), false);
+  assert.equal(filterCourse(cop, { departments: ['CISE'] }), true);
+  assert.equal(filterCourse(mac, { departments: ['CISE'] }), false);
+});
+
+test('filterCourse respects numberMin/numberMax', () => {
+  const c3502 = course('COP3502');
+  const c4930 = course('CAP4930');
+  assert.equal(filterCourse(c3502, { numberMin: 4000 }), false);
+  assert.equal(filterCourse(c4930, { numberMin: 4000 }), true);
+  assert.equal(filterCourse(c4930, { numberMax: 4000 }), false);
+});
+
+test('dedupCourses keeps the last entry for a given key', () => {
+  const out = dedupCourses('UF', '20261', [
+    course('COP3502', { title: 'Old' }),
+    course('COP3502', { title: 'New' }),
+  ]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].title, 'New');
+});
+
+test('dedupSections keeps the last entry for a given classNumber', () => {
+  const out = dedupSections('UF', '20261', [
+    {
+      classNumber: '12345',
+      courseCode: 'COP3502',
+      instructors: [],
+      meetingTimes: [],
+    },
+    {
+      classNumber: '12345',
+      courseCode: 'COP3502',
+      instructors: [{ name: 'Dr Updated' }],
+      meetingTimes: [],
+    },
+    {
+      classNumber: '22222',
+      courseCode: 'COP3502',
+      instructors: [],
+      meetingTimes: [],
+    },
+  ]);
+  assert.equal(out.length, 2);
+  const updated = out.find((s) => s.classNumber === '12345');
+  assert.equal(updated?.instructors[0]?.name, 'Dr Updated');
+});
+
+test('finalizeCourse fills codeWithSpace and department', () => {
+  const c = finalizeCourse(course('cop3502'));
+  assert.equal(c.code, 'COP3502');
+  assert.equal(c.codeWithSpace, 'COP 3502');
+  assert.equal(c.department, 'COP');
+});
+
+test('finalizeSection normalizes meeting times to 24h when possible', () => {
+  const s = finalizeSection({
+    classNumber: ' 123 ',
+    courseCode: 'cop3502',
+    instructors: [{ name: ' Alice ', email: 'a@b.c' }],
+    meetingTimes: [
+      {
+        day: 'M',
+        startTime: '12:50 pm',
+        endTime: '1:40 pm',
+        building: 'LIT',
+        room: '109',
+      },
+      { day: 'T', startTime: 'period 3' }, // unnormalizable
+    ],
+  });
+  assert.equal(s.classNumber, '123');
+  assert.equal(s.courseCode, 'COP3502');
+  assert.equal(s.instructors[0]?.name, 'Alice');
+  assert.equal(s.meetingTimes[0]?.startTime, '12:50');
+  assert.equal(s.meetingTimes[0]?.endTime, '13:40');
+  assert.equal(s.meetingTimes[0]?.location, 'LIT 109');
+  assert.equal(s.meetingTimes[1]?.startTime, undefined);
+});
+
+test('courseKey is stable and uppercased', () => {
+  assert.equal(courseKey('UF', '20261', 'cop3502'), 'UF:20261:COP3502');
+});
+
+// --- provider: UF term code ---
+
+test('ufTermCode maps spring/summer/fall correctly', () => {
+  assert.equal(ufTermCode({ term: 'spring', year: 2026 }), '2261');
+  assert.equal(ufTermCode({ term: 'summer', year: 2026 }), '2265');
+  assert.equal(ufTermCode({ term: 'fall', year: 2026 }), '2268');
+});
+
+// --- validation ---
+
+test('validateConfigInput accepts a minimal valid config', () => {
+  const res = validateConfigInput({
+    label: 'UF Spring CISE',
+    provider: 'UF',
+    institution: 'UF',
+    term: 'spring',
+    year: 2026,
+    enabled: true,
+    refresh: { mode: 'manual' },
+  });
+  assert.equal(res.ok, true);
+});
+
+test('validateConfigInput rejects bad term / provider / prefixes', () => {
+  const res = validateConfigInput({
+    label: '',
+    provider: 'MIT',
+    term: 'winter',
+    year: 1800,
+    departments: ['cs4life'],
+    codePrefixes: ['x'],
+    refresh: { mode: 'monthly' },
+  });
+  assert.equal(res.ok, false);
+  assert.ok(!res.ok && res.errors.length >= 4);
+});
+
+test('validateConfigInput enforces everyHours range for everyNHours', () => {
+  const bad = validateConfigInput({
+    label: 'x',
+    provider: 'UF',
+    term: 'fall',
+    year: 2026,
+    refresh: { mode: 'everyNHours', everyHours: 9999 },
+  });
+  assert.equal(bad.ok, false);
+  const good = validateConfigInput({
+    label: 'x',
+    provider: 'UF',
+    term: 'fall',
+    year: 2026,
+    refresh: { mode: 'everyNHours', everyHours: 6 },
+  });
+  assert.equal(good.ok, true);
+});
+
+test('computeNextRefreshAt is null for manual and future for interval modes', () => {
+  const now = new Date('2026-04-23T12:00:00Z');
+  assert.equal(computeNextRefreshAt({ mode: 'manual' }, now), null);
+  const hourly = computeNextRefreshAt({ mode: 'hourly' }, now);
+  assert.ok(hourly);
+  assert.ok(hourly!.getTime() - now.getTime() === 60 * 60 * 1000);
+  const every = computeNextRefreshAt(
+    { mode: 'everyNHours', everyHours: 6 },
+    now
+  );
+  assert.ok(every!.getTime() - now.getTime() === 6 * 60 * 60 * 1000);
+});
+
+// --- pipeline integration with a stub fetcher ---
+
+function ufResponse(courses: unknown[], retrievedRows = courses.length) {
+  return [
+    {
+      COURSES: courses,
+      LASTCONTROLNUMBER: 0,
+      TOTALROWS: courses.length,
+      RETRIEVEDROWS: retrievedRows,
+    },
+  ];
+}
+
+test('fetchCoursesForConfig handles a single page and dedups', async () => {
+  const calls: string[] = [];
+  // First page has a course with duplicate sections; next page signals end.
+  const firstPage = ufResponse([
+    {
+      code: 'COP3502',
+      name: 'Programming Fundamentals 1',
+      deptName: 'CISE',
+      sections: [
+        {
+          classNumber: '11111',
+          number: '001',
+          instructors: [{ name: 'A. Alpha' }],
+          meetTimes: [
+            {
+              meetDays: ['M', 'W', 'F'],
+              meetTimeBegin: '12:50 PM',
+              meetTimeEnd: '1:40 PM',
+              meetBuilding: 'LIT',
+              meetRoom: '109',
+            },
+          ],
+        },
+        {
+          classNumber: '11111',
+          number: '001',
+          instructors: [{ name: 'B. Beta' }],
+          meetTimes: [],
+        },
+      ],
+    },
+  ]);
+  const emptyPage = ufResponse([], 0); // signals the worker to stop
+
+  const stub: Fetcher = async (url: string) => {
+    calls.push(url);
+    // 1st request = start of walk (control=0) → data. 2nd = next stride → empty.
+    const body = calls.length === 1 ? firstPage : emptyPage;
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  const result = await fetchCoursesForConfig(
+    {
+      id: 'cfg-1',
+      provider: 'UF',
+      institution: 'UF',
+      term: 'fall',
+      year: 2026,
+      filters: { codePrefixes: ['COP'] },
+      concurrency: 1,
+    },
+    { fetcher: stub }
+  );
+
+  assert.equal(result.status, 'success');
+  assert.equal(result.courses.length, 1);
+  assert.equal(result.courses[0].code, 'COP3502');
+  assert.equal(result.sections.length, 1);
+  assert.equal(result.sections[0].instructors[0]?.name, 'B. Beta');
+  assert.equal(
+    (result.providerMeta as Record<string, unknown>).termCode,
+    '2268'
+  );
+  // Single worker: one data page + one empty page to terminate.
+  assert.equal(calls.length, 2);
+  // Category=RES and stride increments by PAGE_SIZE between calls.
+  assert.match(calls[0], /[?&]category=RES(&|$)/);
+  assert.match(calls[0], /[?&]last-control-number=0(&|$)/);
+  assert.match(calls[1], /[?&]last-control-number=50(&|$)/);
+});
+
+test('stride-parallel walk: workers start at PAGE_SIZE*i with stride PAGE_SIZE*N', async () => {
+  const seen = new Set<number>();
+  const stub: Fetcher = async (url: string) => {
+    const m = url.match(/last-control-number=(\d+)/);
+    const n = m ? Number(m[1]) : -1;
+    seen.add(n);
+    return new Response(JSON.stringify(ufResponse([], 0)), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  await fetchCoursesForConfig(
+    {
+      id: 'cfg-stride',
+      provider: 'UF',
+      institution: 'UF',
+      term: 'spring',
+      year: 2026,
+      filters: {},
+      concurrency: 4,
+    },
+    { fetcher: stub }
+  );
+
+  // With N=4: workers start at 0, 50, 100, 150, each terminates on first
+  // empty page. Seen set should include exactly those offsets.
+  assert.deepEqual(
+    Array.from(seen).sort((a, b) => a - b),
+    [0, 50, 100, 150]
+  );
+});
+
+test('fetchCoursesForConfig marks failed when every worker errors', async () => {
+  const stub: Fetcher = async () => new Response('oops', { status: 500 });
+  const result = await fetchCoursesForConfig(
+    {
+      id: 'cfg-2',
+      provider: 'UF',
+      institution: 'UF',
+      term: 'spring',
+      year: 2026,
+      filters: { departments: ['CISE'] },
+      concurrency: 1,
+    },
+    { fetcher: stub }
+  );
+  assert.equal(result.status, 'failed');
+  assert.ok(result.errors.length > 0);
+});
+
+test('fetchCoursesForConfig handles non-JSON gracefully', async () => {
+  const stub: Fetcher = async () =>
+    new Response('<html>oops</html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+  const result = await fetchCoursesForConfig(
+    {
+      id: 'cfg-3',
+      provider: 'UF',
+      institution: 'UF',
+      term: 'fall',
+      year: 2026,
+      filters: {},
+      concurrency: 1,
+    },
+    { fetcher: stub }
+  );
+  assert.equal(result.status, 'failed');
+  assert.ok(result.errors.some((e) => e.includes('non-JSON')));
+});

--- a/functions/src/courseFetcher/normalize.ts
+++ b/functions/src/courseFetcher/normalize.ts
@@ -1,0 +1,211 @@
+// Pure helpers for cleaning and normalizing course / section data.
+// Everything here must be side-effect free so it can be unit-tested.
+
+import type {
+  FilterOptions,
+  NormalizedCourse,
+  NormalizedMeetingTime,
+  NormalizedSection,
+} from './types';
+
+// 'COP3502' -> 'COP 3502'. Returns input unchanged if it already has a space
+// or doesn't match the letters-then-digits shape.
+export function addCodeSpace(code: string): string {
+  const trimmed = code.trim();
+  if (/\s/.test(trimmed)) return trimmed;
+  const m = trimmed.match(/^([A-Z]{2,4})(\d{3,4}[A-Z]?)$/);
+  if (!m) return trimmed;
+  return `${m[1]} ${m[2]}`;
+}
+
+// Derive a department-ish bucket from a course code prefix when the provider
+// didn't give one. e.g. 'COP3502' -> 'COP'. Returns '' when indeterminate.
+export function departmentFromCode(code: string): string {
+  const m = code.trim().match(/^([A-Z]{2,4})/);
+  return m ? m[1] : '';
+}
+
+// 'period 3' / '3rd period' / '12:50 pm' / '1250' — UF's schedule API returns
+// time in a few shapes. We try to produce 'HH:MM' 24h. Returns undefined if
+// we can't normalize; callers should fall back to `rawTime`.
+export function to24h(time: string | undefined | null): string | undefined {
+  if (!time) return undefined;
+  const s = String(time).trim();
+  if (!s) return undefined;
+
+  // Already 24h HH:MM
+  const hhmm = s.match(/^(\d{1,2}):(\d{2})$/);
+  if (hhmm) {
+    const h = Number(hhmm[1]);
+    const m = Number(hhmm[2]);
+    if (h >= 0 && h <= 23 && m >= 0 && m <= 59) {
+      return `${String(h).padStart(2, '0')}:${hhmm[2]}`;
+    }
+  }
+
+  // 12h with am/pm: '12:50 pm', '1:00am'
+  const twelve = s.match(/^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i);
+  if (twelve) {
+    let h = Number(twelve[1]);
+    const m = twelve[2] ? Number(twelve[2]) : 0;
+    const suffix = twelve[3].toLowerCase();
+    if (h === 12) h = 0;
+    if (suffix === 'pm') h += 12;
+    if (h >= 0 && h <= 23 && m >= 0 && m <= 59) {
+      return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+    }
+  }
+
+  // 4-digit military time: '1250'
+  const digits = s.match(/^(\d{3,4})$/);
+  if (digits) {
+    const raw = digits[1].padStart(4, '0');
+    const h = Number(raw.slice(0, 2));
+    const m = Number(raw.slice(2));
+    if (h >= 0 && h <= 23 && m >= 0 && m <= 59) {
+      return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+    }
+  }
+
+  return undefined;
+}
+
+// Combine building + room into a friendly location string.
+export function joinLocation(
+  building: string | undefined,
+  room: string | undefined
+): string | undefined {
+  const b = (building ?? '').trim();
+  const r = (room ?? '').trim();
+  if (!b && !r) return undefined;
+  if (!b) return r;
+  if (!r) return b;
+  return `${b} ${r}`;
+}
+
+// Build a stable, sortable key for dedup and writes.
+// Courses: `${provider}:${termCode}:${code}`
+// Sections: `${provider}:${termCode}:${classNumber}`
+export function courseKey(
+  provider: string,
+  termCode: string,
+  code: string
+): string {
+  return `${provider}:${termCode}:${code.trim().toUpperCase()}`;
+}
+export function sectionKey(
+  provider: string,
+  termCode: string,
+  classNumber: string
+): string {
+  return `${provider}:${termCode}:${classNumber.trim()}`;
+}
+
+// Apply admin-configured filters. Provider filters (e.g. department=CISE on
+// the API) are a best-effort optimization; this is the authoritative cut.
+export function filterCourse(
+  course: NormalizedCourse,
+  f: FilterOptions
+): boolean {
+  if (f.codePrefixes && f.codePrefixes.length > 0) {
+    const prefix = departmentFromCode(course.code);
+    if (!f.codePrefixes.some((p) => prefix === p.toUpperCase())) return false;
+  }
+
+  if (f.departments && f.departments.length > 0) {
+    const dept = (
+      course.department ?? departmentFromCode(course.code)
+    ).toUpperCase();
+    if (!f.departments.some((d) => dept === d.toUpperCase())) return false;
+  }
+
+  // Number range filter — pull trailing digits from the code.
+  if (f.numberMin != null || f.numberMax != null) {
+    const digits = course.code.match(/(\d{3,4})/);
+    const num = digits ? Number(digits[1]) : NaN;
+    if (!Number.isFinite(num)) return false;
+    if (f.numberMin != null && num < f.numberMin) return false;
+    if (f.numberMax != null && num > f.numberMax) return false;
+  }
+
+  if (f.level && f.level !== 'any' && course.level && course.level !== 'any') {
+    if (course.level !== f.level) return false;
+  }
+  return true;
+}
+
+// Deduplicate on the stable course/section keys. Later entries replace
+// earlier ones so a fresh fetch can correct stale data within a single run.
+export function dedupCourses(
+  provider: string,
+  termCode: string,
+  courses: NormalizedCourse[]
+): NormalizedCourse[] {
+  const map = new Map<string, NormalizedCourse>();
+  for (const c of courses) {
+    if (!c.code) continue;
+    map.set(courseKey(provider, termCode, c.code), c);
+  }
+  return Array.from(map.values()).sort((a, b) => a.code.localeCompare(b.code));
+}
+
+export function dedupSections(
+  provider: string,
+  termCode: string,
+  sections: NormalizedSection[]
+): NormalizedSection[] {
+  const map = new Map<string, NormalizedSection>();
+  for (const s of sections) {
+    if (!s.classNumber) continue;
+    map.set(sectionKey(provider, termCode, s.classNumber), s);
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.courseCode === b.courseCode
+      ? a.classNumber.localeCompare(b.classNumber)
+      : a.courseCode.localeCompare(b.courseCode)
+  );
+}
+
+export function finalizeCourse(c: NormalizedCourse): NormalizedCourse {
+  const code = (c.code ?? '').trim().toUpperCase();
+  return {
+    ...c,
+    code,
+    codeWithSpace: addCodeSpace(code),
+    department: (c.department ?? departmentFromCode(code)).toUpperCase(),
+  };
+}
+
+export function finalizeMeetingTimes(
+  times: NormalizedMeetingTime[] | undefined
+): NormalizedMeetingTime[] {
+  if (!Array.isArray(times)) return [];
+  return times.map((t) => {
+    const start = to24h(t.startTime);
+    const end = to24h(t.endTime);
+    return {
+      day: (t.day ?? '').trim(),
+      startTime: start,
+      endTime: end,
+      rawTime: !start && !end ? t.rawTime ?? undefined : t.rawTime,
+      building: t.building,
+      room: t.room,
+      location: t.location ?? joinLocation(t.building, t.room),
+    };
+  });
+}
+
+export function finalizeSection(s: NormalizedSection): NormalizedSection {
+  return {
+    ...s,
+    classNumber: String(s.classNumber ?? '').trim(),
+    courseCode: (s.courseCode ?? '').trim().toUpperCase(),
+    meetingTimes: finalizeMeetingTimes(s.meetingTimes),
+    instructors: Array.isArray(s.instructors)
+      ? s.instructors.map((i) => ({
+          name: (i.name ?? '').trim(),
+          email: i.email ? i.email.trim() : undefined,
+        }))
+      : [],
+  };
+}

--- a/functions/src/courseFetcher/pipeline.ts
+++ b/functions/src/courseFetcher/pipeline.ts
@@ -1,0 +1,94 @@
+// Pipeline: orchestrates provider fetch -> filter -> dedup -> finalize.
+// Persistence is the caller's responsibility (see runAndPersist in runner.ts).
+
+import {
+  dedupCourses,
+  dedupSections,
+  filterCourse,
+  finalizeCourse,
+  finalizeSection,
+} from './normalize';
+import { ufProvider } from './providers/uf';
+import type {
+  ConfigSnapshot,
+  Fetcher,
+  FetchResult,
+  Provider,
+  ProviderId,
+} from './types';
+
+const PROVIDERS: Record<ProviderId, Provider> = {
+  UF: ufProvider,
+};
+
+export function getProvider(id: ProviderId): Provider {
+  const p = PROVIDERS[id];
+  if (!p) throw new Error(`Unknown provider: ${id}`);
+  return p;
+}
+
+export async function fetchCoursesForConfig(
+  config: ConfigSnapshot,
+  options: { fetcher?: Fetcher } = {}
+): Promise<FetchResult> {
+  const provider = getProvider(config.provider);
+  const termCode =
+    (config.termCode && config.termCode.trim()) ||
+    provider.resolveTermCode({ term: config.term, year: config.year });
+
+  let providerResult;
+  try {
+    providerResult = await provider.fetch({
+      config,
+      termCode,
+      fetcher: options.fetcher,
+    });
+  } catch (err) {
+    return {
+      status: 'failed',
+      rawCount: 0,
+      courses: [],
+      sections: [],
+      errors: [err instanceof Error ? err.message : String(err)],
+      warnings: [],
+    };
+  }
+
+  const rawCount = providerResult.rawCount;
+
+  const filtered = providerResult.courses
+    .map(finalizeCourse)
+    .filter((c) => filterCourse(c, config.filters));
+  const allowedCodes = new Set(filtered.map((c) => c.code));
+
+  const filteredSections = providerResult.sections
+    .map(finalizeSection)
+    .filter((s) => allowedCodes.has(s.courseCode));
+
+  const dedupedCourses = dedupCourses(config.provider, termCode, filtered);
+  const dedupedSections = dedupSections(
+    config.provider,
+    termCode,
+    filteredSections
+  );
+
+  const errors = providerResult.errors ?? [];
+  const warnings = providerResult.warnings ?? [];
+
+  const status: FetchResult['status'] =
+    errors.length === 0
+      ? 'success'
+      : dedupedCourses.length > 0
+      ? 'partial_success'
+      : 'failed';
+
+  return {
+    status,
+    rawCount,
+    courses: dedupedCourses,
+    sections: dedupedSections,
+    errors,
+    warnings,
+    providerMeta: { termCode },
+  };
+}

--- a/functions/src/courseFetcher/providers/uf.ts
+++ b/functions/src/courseFetcher/providers/uf.ts
@@ -1,0 +1,343 @@
+// UF (University of Florida) provider for the course-fetch pipeline.
+//
+// Source: ONE.UF schedule API at `https://one.uf.edu/apix/soc/schedule/`.
+// This mirrors the logic of the original UFCourseGrabber.py reference
+// implementation — specifically:
+//   - `category=RES` and `term=<code>` query parameters
+//   - Pagination by stride: each parallel worker walks
+//     `last-control-number = 50*i, 50*i + 50*N, 50*i + 100*N, ...` where N
+//     is the total concurrency. A worker stops when its response reports
+//     `RETRIEVEDROWS == 0`.
+//   - No provider-level department/prefix filter — ONE.UF's endpoint does
+//     not expose those, so filtering happens in the pipeline after
+//     normalization.
+//
+// Security note: the endpoint is intended to be callable without personal
+// session cookies. If a deployment environment requires a cookie, it is
+// read from `process.env.ONE_UF_COOKIE` at runtime only — never hardcoded.
+
+import type {
+  ConfigSnapshot,
+  Fetcher,
+  NormalizedCourse,
+  NormalizedMeetingTime,
+  NormalizedSection,
+  Provider,
+  SemesterTermLower,
+} from '../types';
+
+const ONE_UF_BASE = 'https://one.uf.edu/apix/soc/schedule/';
+const PAGE_SIZE = 50; // ONE.UF returns up to 50 courses per last-control-number.
+
+// UF term codes: "2" + YY + termDigit. termDigit: spring=1, summer=5, fall=8.
+// Matches UFCourseGrabber.py's `term_dict`.
+const UF_TERM_DIGIT: Record<SemesterTermLower, string> = {
+  spring: '1',
+  summer: '5',
+  fall: '8',
+};
+
+export function ufTermCode(input: {
+  term: SemesterTermLower;
+  year: number;
+}): string {
+  const digit = UF_TERM_DIGIT[input.term];
+  if (!digit) throw new Error(`Unsupported term: ${input.term}`);
+  const yy = String(input.year).slice(-2).padStart(2, '0');
+  return `2${yy}${digit}`;
+}
+
+// Defensive accessor — never throws on missing keys.
+function pick(obj: unknown, key: string): unknown {
+  if (!obj || typeof obj !== 'object') return undefined;
+  return (obj as Record<string, unknown>)[key];
+}
+function str(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  const s = String(v).trim();
+  return s.length ? s : undefined;
+}
+function num(v: unknown): number | undefined {
+  if (v == null || v === '') return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function buildUrl(termCode: string, lastControlNumber: number): string {
+  const params = new URLSearchParams();
+  params.set('category', 'RES');
+  params.set('term', termCode);
+  params.set('last-control-number', String(lastControlNumber));
+  return `${ONE_UF_BASE}?${params.toString()}`;
+}
+
+function defaultHeaders(): Record<string, string> {
+  const h: Record<string, string> = {
+    Accept: 'application/json',
+    'User-Agent':
+      'CourseConnect-Scraper/1.0 (+https://courseconnect.eng.ufl.edu)',
+  };
+  const cookie = process.env.ONE_UF_COOKIE;
+  if (cookie && cookie.trim()) {
+    h.Cookie = cookie.trim();
+  }
+  return h;
+}
+
+async function fetchWithRetry(
+  url: string,
+  fetcher: Fetcher,
+  attempts = 3
+): Promise<Response> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetcher(url, {
+        method: 'GET',
+        headers: defaultHeaders(),
+      });
+      if (res.ok) return res;
+      // Retry on 5xx / 429 only. 4xx other than 429 is a config problem —
+      // bail immediately instead of burning retries.
+      if (res.status !== 429 && res.status < 500) {
+        throw new Error(`HTTP ${res.status} ${res.statusText}`);
+      }
+      lastErr = new Error(`HTTP ${res.status} ${res.statusText}`);
+    } catch (err) {
+      // Non-retryable HTTP errors rethrown from above reach here too; those
+      // come in as `Error` with an `HTTP 4xx` message, which we surface
+      // immediately without further retries.
+      const message = err instanceof Error ? err.message : String(err);
+      if (/^HTTP [34]\d\d/.test(message) && !/^HTTP 429/.test(message)) {
+        throw err;
+      }
+      lastErr = err;
+    }
+    // Exponential backoff with jitter: 250ms, 750ms, 1750ms.
+    const delay = 250 * 2 ** i + Math.floor(Math.random() * 150);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+  throw lastErr instanceof Error ? lastErr : new Error('fetch failed');
+}
+
+type UFPage = {
+  rawCourses: unknown[];
+  retrievedRows: number; // ONE.UF's RETRIEVEDROWS — 0 means "no more data".
+};
+
+async function fetchPage(url: string, fetcher: Fetcher): Promise<UFPage> {
+  const res = await fetchWithRetry(url, fetcher);
+  const text = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('ONE.UF returned non-JSON response');
+  }
+
+  // Response shape: [ { COURSES: [...], LASTCONTROLNUMBER, TOTALROWS, RETRIEVEDROWS } ]
+  const root = Array.isArray(parsed) ? parsed[0] : parsed;
+  const coursesField = pick(root, 'COURSES');
+  const rawCourses = Array.isArray(coursesField) ? coursesField : [];
+  const retrievedRows = num(pick(root, 'RETRIEVEDROWS')) ?? rawCourses.length;
+  return { rawCourses, retrievedRows };
+}
+
+// Very defensive: any field can be missing. We never throw on shape.
+function normalizeCourseRow(row: unknown): {
+  course: NormalizedCourse | null;
+  sections: NormalizedSection[];
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  const code = str(pick(row, 'code')) ?? str(pick(row, 'courseCode')) ?? '';
+  if (!code) {
+    return {
+      course: null,
+      sections: [],
+      warnings: ['row missing course code'],
+    };
+  }
+  const title = str(pick(row, 'name')) ?? str(pick(row, 'title')) ?? code;
+  const description = str(pick(row, 'description'));
+  const credits =
+    str(pick(row, 'openCredits')) ?? str(pick(row, 'credits')) ?? undefined;
+  const dept = str(pick(row, 'deptName')) ?? str(pick(row, 'department'));
+
+  const course: NormalizedCourse = {
+    code,
+    codeWithSpace: code, // finalize() will inject the space
+    title,
+    description,
+    credits,
+    department: dept,
+  };
+
+  const rawSections = pick(row, 'sections');
+  const sections: NormalizedSection[] = Array.isArray(rawSections)
+    ? rawSections
+        .map((raw) => normalizeSectionRow(code, raw, warnings))
+        .filter((s): s is NormalizedSection => s !== null)
+    : [];
+  return { course, sections, warnings };
+}
+
+function normalizeSectionRow(
+  courseCode: string,
+  raw: unknown,
+  warnings: string[]
+): NormalizedSection | null {
+  const classNumber =
+    str(pick(raw, 'classNumber')) ?? str(pick(raw, 'classNbr')) ?? '';
+  if (!classNumber) {
+    warnings.push(`section under ${courseCode} missing classNumber`);
+    return null;
+  }
+
+  const sectionNumber =
+    str(pick(raw, 'number')) ?? str(pick(raw, 'sectionNumber'));
+
+  const instructors = (() => {
+    const list = pick(raw, 'instructors');
+    if (!Array.isArray(list)) return [];
+    return list
+      .map((i) => ({
+        name: str(pick(i, 'name')) ?? '',
+        email: str(pick(i, 'email')),
+      }))
+      .filter((i) => i.name);
+  })();
+
+  const meetingTimes: NormalizedMeetingTime[] = (() => {
+    const list = pick(raw, 'meetTimes');
+    if (!Array.isArray(list)) return [];
+    const out: NormalizedMeetingTime[] = [];
+    for (const m of list) {
+      const days = pick(m, 'meetDays');
+      const daysArr = Array.isArray(days)
+        ? days.map((d) => String(d))
+        : [String(days ?? '')];
+      const dayStr = daysArr.filter(Boolean).join('');
+      const start = str(pick(m, 'meetTimeBegin')) ?? str(pick(m, 'startTime'));
+      const end = str(pick(m, 'meetTimeEnd')) ?? str(pick(m, 'endTime'));
+      const building = str(pick(m, 'meetBuilding')) ?? str(pick(m, 'building'));
+      const room = str(pick(m, 'meetRoom')) ?? str(pick(m, 'room'));
+      out.push({
+        day: dayStr,
+        startTime: start,
+        endTime: end,
+        rawTime:
+          !start && !end
+            ? str(pick(m, 'meetPeriodBegin')) ?? str(pick(m, 'rawTime'))
+            : undefined,
+        building,
+        room,
+      });
+    }
+    return out;
+  })();
+
+  return {
+    classNumber,
+    sectionNumber,
+    courseCode,
+    instructors,
+    meetingTimes,
+    enrollmentCap:
+      num(pick(raw, 'enrollmentCap')) ?? num(pick(raw, 'classCapacity')),
+    enrolled: num(pick(raw, 'enrolled')) ?? num(pick(raw, 'enrollment')),
+    waitlistCap: num(pick(raw, 'waitListCap')),
+    waitlisted: num(pick(raw, 'waitListed')),
+    campus: str(pick(raw, 'campus')),
+    deliveryMode:
+      str(pick(raw, 'instructionMethod')) ?? str(pick(raw, 'deliveryMode')),
+  };
+}
+
+// One worker walks last-control-number = start, start+stride, start+2*stride, ...
+// stopping when its response reports RETRIEVEDROWS == 0. Each worker records
+// errors independently so a single shard failing does not abort the run.
+async function walkStride(params: {
+  termCode: string;
+  start: number;
+  stride: number;
+  fetcher: Fetcher;
+}): Promise<{ rawCourses: unknown[]; errors: string[] }> {
+  const { termCode, start, stride, fetcher } = params;
+  const rawCourses: unknown[] = [];
+  const errors: string[] = [];
+  let last = start;
+  // Safety cap: 400 * stride ~= 20k control numbers per worker, far above
+  // any real term size. Prevents infinite loops on provider bugs.
+  for (let i = 0; i < 400; i++) {
+    const url = buildUrl(termCode, last);
+    let page: UFPage;
+    try {
+      page = await fetchPage(url, fetcher);
+    } catch (err) {
+      errors.push(
+        `worker(start=${start}, last=${last}): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      break;
+    }
+    if (page.retrievedRows === 0) break;
+    if (page.rawCourses.length > 0) rawCourses.push(...page.rawCourses);
+    last += stride;
+  }
+  return { rawCourses, errors };
+}
+
+export const ufProvider: Provider = {
+  id: 'UF',
+  resolveTermCode: ufTermCode,
+  async fetch({ config, termCode, fetcher }) {
+    const use = fetcher ?? (globalThis.fetch as Fetcher);
+    const warnings: string[] = [];
+    const errors: string[] = [];
+    const normalizedCourses: NormalizedCourse[] = [];
+    const normalizedSections: NormalizedSection[] = [];
+
+    // Stride-parallel walk matching UFCourseGrabber.py. Workers are
+    // independent — if one errors, others keep going. Filters are applied
+    // later by the pipeline since the ONE.UF endpoint doesn't support
+    // department/prefix parameters.
+    const workerCount = Math.max(1, Math.min(config.concurrency, 16));
+    const stride = PAGE_SIZE * workerCount;
+    const workers: Array<Promise<{ rawCourses: unknown[]; errors: string[] }>> =
+      [];
+    for (let i = 0; i < workerCount; i++) {
+      workers.push(
+        walkStride({
+          termCode,
+          start: PAGE_SIZE * i,
+          stride,
+          fetcher: use,
+        })
+      );
+    }
+    const results = await Promise.all(workers);
+    for (const r of results) {
+      if (r.errors.length) errors.push(...r.errors);
+      for (const row of r.rawCourses) {
+        const {
+          course,
+          sections,
+          warnings: rowWarnings,
+        } = normalizeCourseRow(row);
+        if (rowWarnings.length) warnings.push(...rowWarnings);
+        if (course) normalizedCourses.push(course);
+        for (const s of sections) normalizedSections.push(s);
+      }
+    }
+
+    return {
+      rawCount: normalizedCourses.length,
+      courses: normalizedCourses,
+      sections: normalizedSections,
+      errors,
+      warnings,
+    };
+  },
+};

--- a/functions/src/courseFetcher/runner.ts
+++ b/functions/src/courseFetcher/runner.ts
@@ -1,0 +1,224 @@
+// Orchestrates a single fetch run: fetch -> persist normalized data ->
+// write a run record -> update the parent config's status fields.
+//
+// All Firestore writes go through batched writes with a hard cap so we
+// never exceed the 500-op batch limit.
+
+import * as admin from 'firebase-admin';
+import { fetchCoursesForConfig } from './pipeline';
+import {
+  computeNextRefreshAt,
+  toConfigSnapshot,
+  type ValidatedConfig,
+} from './validation';
+import type { FetchResult } from './types';
+
+const BATCH_LIMIT = 450; // leave headroom below the 500-op Firestore limit
+
+function now(): FirebaseFirestore.FieldValue {
+  return admin.firestore.FieldValue.serverTimestamp();
+}
+
+export interface RunContext {
+  db: FirebaseFirestore.Firestore;
+  configId: string;
+  config: ValidatedConfig;
+  triggeredBy: 'manual' | 'scheduled';
+  triggeredByUid?: string;
+  leaseToken?: string;
+}
+
+export interface RunOutcome {
+  runId: string;
+  status: FetchResult['status'];
+  rawCount: number;
+  courseCount: number;
+  sectionCount: number;
+  durationMs: number;
+  errors: string[];
+  warnings: string[];
+}
+
+async function commitCoursesAndSections(
+  db: FirebaseFirestore.Firestore,
+  configId: string,
+  provider: string,
+  result: FetchResult
+): Promise<void> {
+  const catalog = db.collection('catalog');
+  const termCode =
+    (result.providerMeta &&
+      (result.providerMeta as Record<string, unknown>).termCode) ||
+    '';
+  const prefix = `${provider}:${termCode}`;
+
+  type Op = () => void;
+  let batch = db.batch();
+  let ops = 0;
+  const flush = async () => {
+    if (ops === 0) return;
+    await batch.commit();
+    batch = db.batch();
+    ops = 0;
+  };
+  const add = async (op: Op) => {
+    op();
+    ops++;
+    if (ops >= BATCH_LIMIT) await flush();
+  };
+
+  for (const course of result.courses) {
+    const id = `${prefix}:${course.code}`;
+    const ref = catalog.doc(id);
+    const payload = {
+      ...course,
+      id,
+      provider,
+      termCode,
+      lastUpdated: now(),
+      sourceConfigId: configId,
+    };
+    await add(() => batch.set(ref, payload, { merge: true }));
+  }
+
+  for (const section of result.sections) {
+    const parentId = `${prefix}:${section.courseCode}`;
+    const sectionId = `${prefix}:${section.classNumber}`;
+    const ref = catalog.doc(parentId).collection('sections').doc(sectionId);
+    const payload = {
+      ...section,
+      id: sectionId,
+      courseId: parentId,
+      provider,
+      termCode,
+      lastUpdated: now(),
+      sourceConfigId: configId,
+    };
+    await add(() => batch.set(ref, payload, { merge: true }));
+  }
+
+  await flush();
+}
+
+export async function runAndPersist(ctx: RunContext): Promise<RunOutcome> {
+  const { db, configId, config, triggeredBy, triggeredByUid } = ctx;
+  const runRef = db
+    .collection('courseFetchConfigs')
+    .doc(configId)
+    .collection('runs')
+    .doc();
+  const runId = runRef.id;
+  const startedAt = new Date();
+
+  await runRef.set({
+    runId,
+    configId,
+    startedAt: now(),
+    status: 'running',
+    rawCount: 0,
+    courseCount: 0,
+    sectionCount: 0,
+    errors: [],
+    warnings: [],
+    triggeredBy,
+    ...(triggeredByUid ? { triggeredByUid } : {}),
+  });
+
+  await db.collection('courseFetchConfigs').doc(configId).set(
+    {
+      lastRunId: runId,
+      lastStatus: 'running',
+      lastAttemptAt: now(),
+    },
+    { merge: true }
+  );
+
+  const snapshot = toConfigSnapshot(configId, config);
+  let result: FetchResult;
+  try {
+    result = await fetchCoursesForConfig(snapshot);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const finishedAt = new Date();
+    const durationMs = finishedAt.getTime() - startedAt.getTime();
+    await runRef.set(
+      {
+        finishedAt: now(),
+        status: 'failed',
+        errors: [message],
+        durationMs,
+      },
+      { merge: true }
+    );
+    await db
+      .collection('courseFetchConfigs')
+      .doc(configId)
+      .set(
+        {
+          lastStatus: 'failed',
+          lastError: message,
+          nextRefreshAt: computeNextRefreshAt(config.refresh, finishedAt),
+        },
+        { merge: true }
+      );
+    return {
+      runId,
+      status: 'failed',
+      rawCount: 0,
+      courseCount: 0,
+      sectionCount: 0,
+      durationMs,
+      errors: [message],
+      warnings: [],
+    };
+  }
+
+  try {
+    await commitCoursesAndSections(db, configId, config.provider, result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    result.status = result.status === 'failed' ? 'failed' : 'partial_success';
+    result.errors.push(`persist: ${message}`);
+  }
+
+  const finishedAt = new Date();
+  const durationMs = finishedAt.getTime() - startedAt.getTime();
+
+  await runRef.set(
+    {
+      finishedAt: now(),
+      status: result.status,
+      rawCount: result.rawCount,
+      courseCount: result.courses.length,
+      sectionCount: result.sections.length,
+      errors: result.errors.slice(0, 50),
+      warnings: result.warnings.slice(0, 50),
+      durationMs,
+    },
+    { merge: true }
+  );
+
+  await db
+    .collection('courseFetchConfigs')
+    .doc(configId)
+    .set(
+      {
+        lastStatus: result.status,
+        lastError: result.errors[0] ?? admin.firestore.FieldValue.delete(),
+        lastSuccessAt: result.status === 'failed' ? undefined : now(),
+        nextRefreshAt: computeNextRefreshAt(config.refresh, finishedAt),
+      },
+      { merge: true }
+    );
+
+  return {
+    runId,
+    status: result.status,
+    rawCount: result.rawCount,
+    courseCount: result.courses.length,
+    sectionCount: result.sections.length,
+    durationMs,
+    errors: result.errors,
+    warnings: result.warnings,
+  };
+}

--- a/functions/src/courseFetcher/types.ts
+++ b/functions/src/courseFetcher/types.ts
@@ -1,0 +1,96 @@
+// Provider-agnostic types used by the course-fetch pipeline.
+// Provider-specific types (UF, etc.) live under ./providers.
+
+export type ProviderId = 'UF';
+export type SemesterTermLower = 'spring' | 'summer' | 'fall';
+export type CourseLevel = 'undergraduate' | 'graduate' | 'any';
+export type CourseCampus = 'main' | 'online' | 'any';
+export type FetchStatus = 'success' | 'partial_success' | 'failed';
+
+export interface FilterOptions {
+  departments?: string[];
+  codePrefixes?: string[];
+  numberMin?: number;
+  numberMax?: number;
+  campus?: CourseCampus;
+  level?: CourseLevel;
+}
+
+export interface ConfigSnapshot {
+  id: string;
+  provider: ProviderId;
+  institution: string;
+  term: SemesterTermLower;
+  year: number;
+  termCode?: string; // optional manual override
+  filters: FilterOptions;
+  concurrency: number;
+}
+
+// Normalized shape that every provider emits and the pipeline persists.
+export interface NormalizedCourse {
+  code: string; // 'COP3502'
+  codeWithSpace: string; // 'COP 3502'
+  title: string;
+  department?: string;
+  description?: string;
+  credits?: string;
+  level?: CourseLevel;
+}
+
+export interface NormalizedMeetingTime {
+  day: string;
+  startTime?: string; // '24h HH:MM'
+  endTime?: string;
+  rawTime?: string;
+  building?: string;
+  room?: string;
+  location?: string;
+}
+
+export interface NormalizedSection {
+  classNumber: string;
+  sectionNumber?: string;
+  courseCode: string;
+  instructors: Array<{ name: string; email?: string }>;
+  meetingTimes: NormalizedMeetingTime[];
+  enrollmentCap?: number;
+  enrolled?: number;
+  waitlistCap?: number;
+  waitlisted?: number;
+  campus?: string;
+  deliveryMode?: string;
+}
+
+export interface FetchResult {
+  status: FetchStatus;
+  rawCount: number;
+  courses: NormalizedCourse[];
+  sections: NormalizedSection[];
+  errors: string[];
+  warnings: string[];
+  providerMeta?: Record<string, unknown>;
+}
+
+export interface Provider {
+  id: ProviderId;
+  // Map a (term, year) to the provider-specific code, e.g. UF: 'fall 2026' -> '20268'
+  resolveTermCode(input: { term: SemesterTermLower; year: number }): string;
+  // Run the paginated fetch + normalize step. The pipeline handles filtering,
+  // dedup, and persistence so providers stay focused on transport + shape.
+  fetch(input: {
+    config: ConfigSnapshot;
+    termCode: string;
+    fetcher?: Fetcher;
+  }): Promise<Omit<FetchResult, 'status'>>;
+}
+
+// Abstracted so tests can inject a deterministic implementation without
+// hitting the network. Production uses Node 20's global `fetch`.
+export type Fetcher = (url: string, init?: RequestInit) => Promise<Response>;
+
+// Public entry point the Cloud Function calls.
+export type FetchCoursesForConfig = (
+  config: ConfigSnapshot,
+  options?: { fetcher?: Fetcher }
+) => Promise<FetchResult>;

--- a/functions/src/courseFetcher/validation.ts
+++ b/functions/src/courseFetcher/validation.ts
@@ -1,0 +1,288 @@
+// Validation for CourseFetchConfig input coming from the admin UI.
+// Keep this dependency-free so it can run in both the Functions runtime and
+// a plain node:test harness.
+
+import type { ConfigSnapshot, SemesterTermLower } from './types';
+
+export type ConfigInput = {
+  label?: unknown;
+  provider?: unknown;
+  institution?: unknown;
+  term?: unknown;
+  year?: unknown;
+  termCode?: unknown;
+  departments?: unknown;
+  codePrefixes?: unknown;
+  numberMin?: unknown;
+  numberMax?: unknown;
+  campus?: unknown;
+  level?: unknown;
+  enabled?: unknown;
+  refresh?: unknown;
+  concurrency?: unknown;
+};
+
+export type ValidatedConfig = {
+  label: string;
+  provider: 'UF';
+  institution: string;
+  term: SemesterTermLower;
+  year: number;
+  termCode?: string;
+  departments: string[];
+  codePrefixes: string[];
+  numberMin?: number;
+  numberMax?: number;
+  campus: 'main' | 'online' | 'any';
+  level: 'undergraduate' | 'graduate' | 'any';
+  enabled: boolean;
+  refresh: {
+    mode: 'manual' | 'hourly' | 'daily' | 'weekly' | 'everyNHours';
+    everyHours?: number;
+  };
+  concurrency: number;
+};
+
+export type ValidationResult =
+  | { ok: true; value: ValidatedConfig }
+  | { ok: false; errors: string[] };
+
+const TERMS: SemesterTermLower[] = ['spring', 'summer', 'fall'];
+const PROVIDERS = ['UF'] as const;
+const CAMPUSES = ['main', 'online', 'any'] as const;
+const LEVELS = ['undergraduate', 'graduate', 'any'] as const;
+const REFRESH_MODES = [
+  'manual',
+  'hourly',
+  'daily',
+  'weekly',
+  'everyNHours',
+] as const;
+const DEPT_CODE = /^[A-Z]{2,6}$/;
+const COURSE_PREFIX = /^[A-Z]{2,4}$/;
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+function toStringArray(
+  v: unknown,
+  pattern: RegExp,
+  field: string,
+  errors: string[]
+): string[] {
+  if (v == null) return [];
+  if (!Array.isArray(v)) {
+    errors.push(`${field} must be an array`);
+    return [];
+  }
+  const out: string[] = [];
+  for (const raw of v) {
+    if (typeof raw !== 'string') {
+      errors.push(`${field} entries must be strings`);
+      continue;
+    }
+    const upper = raw.trim().toUpperCase();
+    if (!pattern.test(upper)) {
+      errors.push(`${field} entry "${raw}" is invalid`);
+      continue;
+    }
+    if (!out.includes(upper)) out.push(upper);
+  }
+  return out;
+}
+
+export function validateConfigInput(input: ConfigInput): ValidationResult {
+  const errors: string[] = [];
+
+  const label = isNonEmptyString(input.label) ? input.label.trim() : '';
+  if (!label || label.length > 120)
+    errors.push('label is required (1–120 chars)');
+
+  const provider = isNonEmptyString(input.provider)
+    ? input.provider.trim()
+    : '';
+  if (!(PROVIDERS as readonly string[]).includes(provider)) {
+    errors.push(`provider must be one of ${PROVIDERS.join(', ')}`);
+  }
+
+  const institution = isNonEmptyString(input.institution)
+    ? input.institution.trim()
+    : provider;
+  if (!institution || institution.length > 32) {
+    errors.push('institution is required (<= 32 chars)');
+  }
+
+  const term = isNonEmptyString(input.term)
+    ? input.term.trim().toLowerCase()
+    : '';
+  if (!(TERMS as readonly string[]).includes(term)) {
+    errors.push(`term must be one of ${TERMS.join(', ')}`);
+  }
+
+  const yearNum = Number(input.year);
+  const year = Number.isFinite(yearNum) ? Math.floor(yearNum) : NaN;
+  if (!Number.isFinite(year) || year < 2000 || year > 2100) {
+    errors.push('year must be between 2000 and 2100');
+  }
+
+  // Optional explicit termCode — only accept digits-only strings up to 8 chars.
+  let termCode: string | undefined;
+  if (
+    input.termCode !== undefined &&
+    input.termCode !== null &&
+    input.termCode !== ''
+  ) {
+    if (
+      !isNonEmptyString(input.termCode) ||
+      !/^[0-9]{1,8}$/.test(input.termCode.trim())
+    ) {
+      errors.push('termCode, if provided, must be 1–8 digits');
+    } else {
+      termCode = input.termCode.trim();
+    }
+  }
+
+  const departments = toStringArray(
+    input.departments,
+    DEPT_CODE,
+    'departments',
+    errors
+  );
+  const codePrefixes = toStringArray(
+    input.codePrefixes,
+    COURSE_PREFIX,
+    'codePrefixes',
+    errors
+  );
+
+  let numberMin: number | undefined;
+  let numberMax: number | undefined;
+  if (input.numberMin != null && input.numberMin !== '') {
+    const n = Number(input.numberMin);
+    if (!Number.isFinite(n) || n < 0 || n > 9999) {
+      errors.push('numberMin must be 0–9999');
+    } else {
+      numberMin = Math.floor(n);
+    }
+  }
+  if (input.numberMax != null && input.numberMax !== '') {
+    const n = Number(input.numberMax);
+    if (!Number.isFinite(n) || n < 0 || n > 9999) {
+      errors.push('numberMax must be 0–9999');
+    } else {
+      numberMax = Math.floor(n);
+    }
+  }
+  if (numberMin != null && numberMax != null && numberMin > numberMax) {
+    errors.push('numberMin cannot exceed numberMax');
+  }
+
+  const campus = isNonEmptyString(input.campus)
+    ? input.campus.trim().toLowerCase()
+    : 'any';
+  if (!(CAMPUSES as readonly string[]).includes(campus)) {
+    errors.push(`campus must be one of ${CAMPUSES.join(', ')}`);
+  }
+
+  const level = isNonEmptyString(input.level)
+    ? input.level.trim().toLowerCase()
+    : 'any';
+  if (!(LEVELS as readonly string[]).includes(level)) {
+    errors.push(`level must be one of ${LEVELS.join(', ')}`);
+  }
+
+  const enabled = input.enabled === true;
+
+  const refreshRaw = (input.refresh ?? {}) as {
+    mode?: unknown;
+    everyHours?: unknown;
+  };
+  const mode = isNonEmptyString(refreshRaw.mode)
+    ? refreshRaw.mode.trim()
+    : 'manual';
+  if (!(REFRESH_MODES as readonly string[]).includes(mode)) {
+    errors.push(`refresh.mode must be one of ${REFRESH_MODES.join(', ')}`);
+  }
+  let everyHours: number | undefined;
+  if (mode === 'everyNHours') {
+    const n = Number(refreshRaw.everyHours);
+    if (!Number.isFinite(n) || n < 1 || n > 168) {
+      errors.push('refresh.everyHours must be 1–168 when mode is everyNHours');
+    } else {
+      everyHours = Math.floor(n);
+    }
+  }
+
+  let concurrency = Number(input.concurrency);
+  if (!Number.isFinite(concurrency)) concurrency = 4;
+  concurrency = Math.max(1, Math.min(16, Math.floor(concurrency)));
+
+  if (errors.length) return { ok: false, errors };
+
+  return {
+    ok: true,
+    value: {
+      label,
+      provider: provider as 'UF',
+      institution,
+      term: term as SemesterTermLower,
+      year,
+      termCode,
+      departments,
+      codePrefixes,
+      numberMin,
+      numberMax,
+      campus: campus as 'main' | 'online' | 'any',
+      level: level as 'undergraduate' | 'graduate' | 'any',
+      enabled,
+      refresh: { mode: mode as ValidatedConfig['refresh']['mode'], everyHours },
+      concurrency,
+    },
+  };
+}
+
+// Convert a validated config into the snapshot shape the pipeline needs.
+export function toConfigSnapshot(
+  id: string,
+  v: ValidatedConfig
+): ConfigSnapshot {
+  return {
+    id,
+    provider: v.provider,
+    institution: v.institution,
+    term: v.term,
+    year: v.year,
+    termCode: v.termCode,
+    filters: {
+      departments: v.departments,
+      codePrefixes: v.codePrefixes,
+      numberMin: v.numberMin,
+      numberMax: v.numberMax,
+      campus: v.campus,
+      level: v.level,
+    },
+    concurrency: v.concurrency,
+  };
+}
+
+// Compute the next refresh time given a refresh mode. Returns null for
+// 'manual' (no automatic scheduling). All other modes return a Date floored
+// to the minute so the scheduler sees stable comparisons.
+export function computeNextRefreshAt(
+  refresh: ValidatedConfig['refresh'],
+  now: Date
+): Date | null {
+  if (refresh.mode === 'manual') return null;
+  const hours =
+    refresh.mode === 'hourly'
+      ? 1
+      : refresh.mode === 'daily'
+      ? 24
+      : refresh.mode === 'weekly'
+      ? 24 * 7
+      : refresh.everyHours ?? 1;
+  const next = new Date(now.getTime() + hours * 60 * 60 * 1000);
+  next.setSeconds(0, 0);
+  return next;
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -666,3 +666,15 @@ export {
   revokePendingMembership,
   materializePendingMemberships,
 } from './invites';
+
+// --- course-fetch pipeline ---
+
+export {
+  listCourseFetchConfigs,
+  createCourseFetchConfig,
+  updateCourseFetchConfig,
+  deleteCourseFetchConfig,
+  triggerCourseFetch,
+  listCourseFetchRuns,
+  scheduledCourseFetchRefresh,
+} from './courseFetch';

--- a/src/app/admin-course-fetch/ConfigForm.tsx
+++ b/src/app/admin-course-fetch/ConfigForm.tsx
@@ -1,0 +1,351 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+} from '@mui/material';
+import {
+  CourseFetchConfig,
+  DEFAULT_COURSE_FETCH_CONFIG,
+} from '@/types/courseFetch';
+
+type Draft = Omit<
+  CourseFetchConfig,
+  'id' | 'createdAt' | 'updatedAt' | 'createdBy' | 'updatedBy'
+>;
+
+export interface ConfigFormProps {
+  open: boolean;
+  initial?: CourseFetchConfig | null;
+  onCancel: () => void;
+  onSubmit: (draft: Draft) => Promise<void>;
+  submitting: boolean;
+}
+
+function draftFromInitial(
+  initial: CourseFetchConfig | null | undefined
+): Draft {
+  if (!initial) return { ...DEFAULT_COURSE_FETCH_CONFIG };
+  return {
+    label: initial.label,
+    provider: initial.provider,
+    institution: initial.institution,
+    term: initial.term,
+    year: initial.year,
+    termCode: initial.termCode,
+    departments: initial.departments ?? [],
+    codePrefixes: initial.codePrefixes ?? [],
+    numberMin: initial.numberMin,
+    numberMax: initial.numberMax,
+    campus: initial.campus ?? 'any',
+    level: initial.level ?? 'any',
+    enabled: initial.enabled,
+    refresh: initial.refresh ?? { mode: 'manual' },
+    concurrency: initial.concurrency ?? 4,
+  };
+}
+
+function joinCsv(values: string[] | undefined): string {
+  return (values ?? []).join(', ');
+}
+function parseCsv(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((v) => v.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+export default function ConfigForm({
+  open,
+  initial,
+  onCancel,
+  onSubmit,
+  submitting,
+}: ConfigFormProps) {
+  const [draft, setDraft] = React.useState<Draft>(draftFromInitial(initial));
+  const [departmentsRaw, setDepartmentsRaw] = React.useState(
+    joinCsv(initial?.departments)
+  );
+  const [prefixesRaw, setPrefixesRaw] = React.useState(
+    joinCsv(initial?.codePrefixes)
+  );
+  const [err, setErr] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    setDraft(draftFromInitial(initial));
+    setDepartmentsRaw(joinCsv(initial?.departments));
+    setPrefixesRaw(joinCsv(initial?.codePrefixes));
+    setErr(null);
+  }, [initial, open]);
+
+  const handleSubmit = async () => {
+    setErr(null);
+    const payload: Draft = {
+      ...draft,
+      departments: parseCsv(departmentsRaw),
+      codePrefixes: parseCsv(prefixesRaw),
+    };
+    try {
+      await onSubmit(payload);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to save');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onCancel} fullWidth maxWidth="sm">
+      <DialogTitle>{initial ? 'Edit config' : 'New config'}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="Label"
+            value={draft.label}
+            onChange={(e) => setDraft({ ...draft, label: e.target.value })}
+            fullWidth
+            required
+          />
+          <Stack direction="row" spacing={2}>
+            <FormControl fullWidth>
+              <InputLabel>Provider</InputLabel>
+              <Select
+                label="Provider"
+                value={draft.provider}
+                onChange={(e) =>
+                  setDraft({ ...draft, provider: e.target.value as 'UF' })
+                }
+              >
+                <MenuItem value="UF">UF</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              label="Institution"
+              value={draft.institution}
+              onChange={(e) =>
+                setDraft({ ...draft, institution: e.target.value })
+              }
+              fullWidth
+            />
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <FormControl fullWidth>
+              <InputLabel>Term</InputLabel>
+              <Select
+                label="Term"
+                value={draft.term}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    term: e.target.value as 'spring' | 'summer' | 'fall',
+                  })
+                }
+              >
+                <MenuItem value="spring">Spring</MenuItem>
+                <MenuItem value="summer">Summer</MenuItem>
+                <MenuItem value="fall">Fall</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              label="Year"
+              type="number"
+              value={draft.year}
+              onChange={(e) =>
+                setDraft({ ...draft, year: Number(e.target.value) })
+              }
+              fullWidth
+              required
+            />
+            <TextField
+              label="Term code (override)"
+              value={draft.termCode ?? ''}
+              onChange={(e) =>
+                setDraft({ ...draft, termCode: e.target.value || undefined })
+              }
+              fullWidth
+            />
+          </Stack>
+          <TextField
+            label="Departments (comma-separated)"
+            helperText="e.g. CISE, ECE. Leave empty for all."
+            value={departmentsRaw}
+            onChange={(e) => setDepartmentsRaw(e.target.value)}
+            fullWidth
+          />
+          <TextField
+            label="Course code prefixes (comma-separated)"
+            helperText="e.g. COP, EEL. Leave empty for all."
+            value={prefixesRaw}
+            onChange={(e) => setPrefixesRaw(e.target.value)}
+            fullWidth
+          />
+          <Stack direction="row" spacing={2}>
+            <TextField
+              label="Number min"
+              type="number"
+              value={draft.numberMin ?? ''}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  numberMin:
+                    e.target.value === '' ? undefined : Number(e.target.value),
+                })
+              }
+              fullWidth
+            />
+            <TextField
+              label="Number max"
+              type="number"
+              value={draft.numberMax ?? ''}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  numberMax:
+                    e.target.value === '' ? undefined : Number(e.target.value),
+                })
+              }
+              fullWidth
+            />
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <FormControl fullWidth>
+              <InputLabel>Campus</InputLabel>
+              <Select
+                label="Campus"
+                value={draft.campus}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    campus: e.target.value as 'main' | 'online' | 'any',
+                  })
+                }
+              >
+                <MenuItem value="any">Any</MenuItem>
+                <MenuItem value="main">Main</MenuItem>
+                <MenuItem value="online">Online</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel>Level</InputLabel>
+              <Select
+                label="Level"
+                value={draft.level}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    level: e.target.value as
+                      | 'undergraduate'
+                      | 'graduate'
+                      | 'any',
+                  })
+                }
+              >
+                <MenuItem value="any">Any</MenuItem>
+                <MenuItem value="undergraduate">Undergraduate</MenuItem>
+                <MenuItem value="graduate">Graduate</MenuItem>
+              </Select>
+            </FormControl>
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <FormControl fullWidth>
+              <InputLabel>Refresh</InputLabel>
+              <Select
+                label="Refresh"
+                value={draft.refresh.mode}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    refresh: {
+                      mode: e.target.value as
+                        | 'manual'
+                        | 'hourly'
+                        | 'daily'
+                        | 'weekly'
+                        | 'everyNHours',
+                      everyHours:
+                        e.target.value === 'everyNHours'
+                          ? draft.refresh.everyHours ?? 6
+                          : undefined,
+                    },
+                  })
+                }
+              >
+                <MenuItem value="manual">Manual only</MenuItem>
+                <MenuItem value="hourly">Hourly</MenuItem>
+                <MenuItem value="daily">Daily</MenuItem>
+                <MenuItem value="weekly">Weekly</MenuItem>
+                <MenuItem value="everyNHours">Every N hours</MenuItem>
+              </Select>
+            </FormControl>
+            {draft.refresh.mode === 'everyNHours' && (
+              <TextField
+                label="Hours"
+                type="number"
+                value={draft.refresh.everyHours ?? 6}
+                onChange={(e) =>
+                  setDraft({
+                    ...draft,
+                    refresh: {
+                      ...draft.refresh,
+                      everyHours: Number(e.target.value),
+                    },
+                  })
+                }
+                fullWidth
+              />
+            )}
+            <TextField
+              label="Concurrency"
+              type="number"
+              inputProps={{ min: 1, max: 16 }}
+              value={draft.concurrency}
+              onChange={(e) =>
+                setDraft({ ...draft, concurrency: Number(e.target.value) })
+              }
+              fullWidth
+            />
+          </Stack>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={draft.enabled}
+                onChange={(e) =>
+                  setDraft({ ...draft, enabled: e.target.checked })
+                }
+              />
+            }
+            label="Enabled"
+          />
+          {err && (
+            <Box sx={{ color: 'error.main', fontSize: 14 }} role="alert">
+              {err}
+            </Box>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={submitting}
+        >
+          {submitting ? 'Saving…' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/app/admin-course-fetch/RunHistoryDialog.tsx
+++ b/src/app/admin-course-fetch/RunHistoryDialog.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Chip,
+  LinearProgress,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { CourseFetchRun, toDateOrNull } from '@/types/courseFetch';
+
+export interface RunHistoryDialogProps {
+  open: boolean;
+  configId: string | null;
+  onClose: () => void;
+  load: (configId: string) => Promise<CourseFetchRun[]>;
+}
+
+function statusColor(
+  status: string
+): 'success' | 'warning' | 'error' | 'default' {
+  if (status === 'success') return 'success';
+  if (status === 'partial_success') return 'warning';
+  if (status === 'failed') return 'error';
+  return 'default';
+}
+
+export default function RunHistoryDialog({
+  open,
+  configId,
+  onClose,
+  load,
+}: RunHistoryDialogProps) {
+  const [runs, setRuns] = React.useState<CourseFetchRun[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open || !configId) return;
+    setLoading(true);
+    setError(null);
+    load(configId)
+      .then(setRuns)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Load failed'))
+      .finally(() => setLoading(false));
+  }, [open, configId, load]);
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Run history</DialogTitle>
+      <DialogContent>
+        {loading && <LinearProgress />}
+        {error && <Typography color="error">{error}</Typography>}
+        {!loading && runs.length === 0 && (
+          <Typography color="text.secondary">No runs yet.</Typography>
+        )}
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {runs.map((r) => {
+            const started = toDateOrNull(r.startedAt);
+            const finished = toDateOrNull(r.finishedAt ?? null);
+            return (
+              <Stack
+                key={r.runId}
+                spacing={0.5}
+                sx={{
+                  p: 2,
+                  borderRadius: 2,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                }}
+              >
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  alignItems="center"
+                  justifyContent="space-between"
+                >
+                  <Chip
+                    size="small"
+                    label={r.status}
+                    color={statusColor(r.status)}
+                  />
+                  <Typography variant="body2" color="text.secondary">
+                    {started?.toLocaleString() ?? '—'}
+                    {finished ? ` → ${finished.toLocaleString()}` : ''}
+                  </Typography>
+                </Stack>
+                <Typography variant="body2">
+                  raw: {r.rawCount} · courses: {r.courseCount} · sections:{' '}
+                  {r.sectionCount} · {r.durationMs ?? '—'}ms · {r.triggeredBy}
+                </Typography>
+                {r.errors && r.errors.length > 0 && (
+                  <Typography variant="body2" color="error">
+                    {r.errors.slice(0, 3).join(' · ')}
+                  </Typography>
+                )}
+                {r.warnings && r.warnings.length > 0 && (
+                  <Typography variant="body2" color="warning.main">
+                    {r.warnings.slice(0, 3).join(' · ')}
+                  </Typography>
+                )}
+              </Stack>
+            );
+          })}
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/admin-course-fetch/page.tsx
+++ b/src/app/admin-course-fetch/page.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { Toaster, toast } from 'react-hot-toast';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/DeleteOutline';
+import HistoryIcon from '@mui/icons-material/History';
+import { useAuth } from '@/firebase/auth/auth_context';
+import GetUserRole from '@/firebase/util/GetUserRole';
+import PageLayout from '@/components/PageLayout/PageLayout';
+import { getNavItems } from '@/hooks/useGetItems';
+import { useCourseFetchApi } from '@/hooks/useCourseFetch';
+import type { CourseFetchConfig } from '@/types/courseFetch';
+import { toDateOrNull } from '@/types/courseFetch';
+import ConfigForm from './ConfigForm';
+import RunHistoryDialog from './RunHistoryDialog';
+
+function statusChip(config: CourseFetchConfig) {
+  const status = config.lastStatus ?? 'idle';
+  const color: 'default' | 'success' | 'warning' | 'error' | 'info' =
+    status === 'success'
+      ? 'success'
+      : status === 'partial_success'
+      ? 'warning'
+      : status === 'failed'
+      ? 'error'
+      : status === 'running'
+      ? 'info'
+      : 'default';
+  return <Chip size="small" label={status} color={color} />;
+}
+
+export default function AdminCourseFetchPage() {
+  const { user } = useAuth();
+  const [role, roleLoading] = GetUserRole(user?.uid);
+
+  const api = useCourseFetchApi();
+  const [configs, setConfigs] = React.useState<CourseFetchConfig[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [formOpen, setFormOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState<CourseFetchConfig | null>(null);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [runningId, setRunningId] = React.useState<string | null>(null);
+  const [historyId, setHistoryId] = React.useState<string | null>(null);
+
+  const reload = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await api.list();
+      setConfigs(list);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to load configs');
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  React.useEffect(() => {
+    if (role === 'admin') reload();
+  }, [role, reload]);
+
+  const handleCreate = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+  const handleEdit = (c: CourseFetchConfig) => {
+    setEditing(c);
+    setFormOpen(true);
+  };
+  const handleDelete = async (c: CourseFetchConfig) => {
+    if (!window.confirm(`Delete "${c.label}"? Runs will also be removed.`))
+      return;
+    try {
+      await api.remove(c.id);
+      toast.success('Config deleted');
+      reload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Delete failed');
+    }
+  };
+
+  const handleToggle = async (c: CourseFetchConfig, enabled: boolean) => {
+    try {
+      await api.update({ ...c, enabled });
+      reload();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Update failed');
+    }
+  };
+
+  const handleTrigger = async (c: CourseFetchConfig) => {
+    setRunningId(c.id);
+    const toastId = toast.loading(`Running ${c.label}…`);
+    try {
+      const res = await api.trigger(c.id);
+      toast.dismiss(toastId);
+      if (res.status === 'success') {
+        toast.success(
+          `Done: ${res.courseCount} courses / ${res.sectionCount} sections`
+        );
+      } else if (res.status === 'partial_success') {
+        toast(
+          `Partial: ${res.courseCount} courses, ${res.errors.length} errors`,
+          {
+            icon: '⚠️',
+          }
+        );
+      } else {
+        toast.error(res.errors[0] ?? 'Run failed');
+      }
+      reload();
+    } catch (e) {
+      toast.dismiss(toastId);
+      toast.error(e instanceof Error ? e.message : 'Run failed');
+    } finally {
+      setRunningId(null);
+    }
+  };
+
+  const handleSubmit = async (
+    draft: Omit<
+      CourseFetchConfig,
+      'id' | 'createdAt' | 'updatedAt' | 'createdBy' | 'updatedBy'
+    >
+  ) => {
+    setSubmitting(true);
+    try {
+      if (editing) {
+        await api.update({ ...draft, id: editing.id });
+        toast.success('Config updated');
+      } else {
+        await api.create(draft);
+        toast.success('Config created');
+      }
+      setFormOpen(false);
+      setEditing(null);
+      reload();
+    } catch (e) {
+      // Leave the dialog open so the user can correct validation errors.
+      toast.error(e instanceof Error ? e.message : 'Save failed');
+      throw e;
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (roleLoading) return <div>Loading…</div>;
+  if (role !== 'admin') return <div>Forbidden</div>;
+
+  return (
+    <PageLayout mainTitle="Course Fetch" navItems={getNavItems(role)}>
+      <Toaster />
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }} alignItems="center">
+        <Button variant="contained" onClick={handleCreate}>
+          New config
+        </Button>
+        <Button variant="outlined" onClick={reload} disabled={loading}>
+          Refresh
+        </Button>
+        {loading && <CircularProgress size={20} />}
+      </Stack>
+
+      <Box sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Label</TableCell>
+              <TableCell>Provider</TableCell>
+              <TableCell>Term</TableCell>
+              <TableCell>Filters</TableCell>
+              <TableCell>Refresh</TableCell>
+              <TableCell>Enabled</TableCell>
+              <TableCell>Last run</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {configs.map((c) => {
+              const lastSuccess = toDateOrNull(c.lastSuccessAt ?? null);
+              const lastAttempt = toDateOrNull(c.lastAttemptAt ?? null);
+              return (
+                <TableRow key={c.id}>
+                  <TableCell>
+                    <Stack>
+                      <Typography>{c.label}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {c.id}
+                      </Typography>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>{c.provider}</TableCell>
+                  <TableCell>
+                    {c.term} {c.year}
+                    {c.termCode ? ` (${c.termCode})` : ''}
+                  </TableCell>
+                  <TableCell>
+                    <Stack>
+                      <Typography variant="body2">
+                        {c.departments.length > 0
+                          ? c.departments.join(', ')
+                          : '—'}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {c.codePrefixes.length > 0
+                          ? c.codePrefixes.join(', ')
+                          : '—'}
+                      </Typography>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    {c.refresh.mode}
+                    {c.refresh.mode === 'everyNHours' && c.refresh.everyHours
+                      ? ` (${c.refresh.everyHours}h)`
+                      : ''}
+                  </TableCell>
+                  <TableCell>
+                    <Switch
+                      checked={!!c.enabled}
+                      onChange={(e) => handleToggle(c, e.target.checked)}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Stack spacing={0.5}>
+                      {statusChip(c)}
+                      <Typography variant="caption" color="text.secondary">
+                        {lastSuccess
+                          ? `ok ${lastSuccess.toLocaleString()}`
+                          : lastAttempt
+                          ? `tried ${lastAttempt.toLocaleString()}`
+                          : '—'}
+                      </Typography>
+                      {c.lastError && (
+                        <Typography variant="caption" color="error">
+                          {c.lastError.slice(0, 80)}
+                        </Typography>
+                      )}
+                    </Stack>
+                  </TableCell>
+                  <TableCell align="right">
+                    <IconButton
+                      size="small"
+                      disabled={runningId === c.id}
+                      onClick={() => handleTrigger(c)}
+                      title="Run now"
+                    >
+                      {runningId === c.id ? (
+                        <CircularProgress size={16} />
+                      ) : (
+                        <PlayArrowIcon fontSize="small" />
+                      )}
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      onClick={() => setHistoryId(c.id)}
+                      title="History"
+                    >
+                      <HistoryIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      onClick={() => handleEdit(c)}
+                      title="Edit"
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={() => handleDelete(c)}
+                      title="Delete"
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+            {!loading && configs.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={8}>
+                  <Typography color="text.secondary">
+                    No configs yet. Click &quot;New config&quot; to create one.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </Box>
+
+      <ConfigForm
+        open={formOpen}
+        initial={editing}
+        onCancel={() => {
+          setFormOpen(false);
+          setEditing(null);
+        }}
+        onSubmit={handleSubmit}
+        submitting={submitting}
+      />
+
+      <RunHistoryDialog
+        open={!!historyId}
+        configId={historyId}
+        onClose={() => setHistoryId(null)}
+        load={api.listRuns}
+      />
+    </PageLayout>
+  );
+}

--- a/src/hooks/useCourseFetch.ts
+++ b/src/hooks/useCourseFetch.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback } from 'react';
+import { callFunction } from '@/firebase/functions/callFunction';
+import type { CourseFetchConfig, CourseFetchRun } from '@/types/courseFetch';
+
+type ConfigPayload = Partial<CourseFetchConfig> & {
+  label: string;
+  provider: 'UF';
+  term: 'spring' | 'summer' | 'fall';
+  year: number;
+};
+
+export function useCourseFetchApi() {
+  const list = useCallback(async (): Promise<CourseFetchConfig[]> => {
+    const res = await callFunction<{ configs: CourseFetchConfig[] }>(
+      'listCourseFetchConfigs',
+      {}
+    );
+    return res.configs ?? [];
+  }, []);
+
+  const create = useCallback(
+    async (payload: ConfigPayload): Promise<{ id: string }> => {
+      return callFunction<{ id: string }>('createCourseFetchConfig', payload);
+    },
+    []
+  );
+
+  const update = useCallback(
+    async (
+      payload: ConfigPayload & { id: string }
+    ): Promise<{ id: string }> => {
+      return callFunction<{ id: string }>('updateCourseFetchConfig', payload);
+    },
+    []
+  );
+
+  const remove = useCallback(async (id: string): Promise<void> => {
+    await callFunction('deleteCourseFetchConfig', { id });
+  }, []);
+
+  const trigger = useCallback(
+    async (
+      id: string
+    ): Promise<{
+      runId: string;
+      status: string;
+      rawCount: number;
+      courseCount: number;
+      sectionCount: number;
+      durationMs: number;
+      errors: string[];
+      warnings: string[];
+    }> => {
+      return callFunction('triggerCourseFetch', { id });
+    },
+    []
+  );
+
+  const listRuns = useCallback(
+    async (id: string, limit = 20): Promise<CourseFetchRun[]> => {
+      const res = await callFunction<{ runs: CourseFetchRun[] }>(
+        'listCourseFetchRuns',
+        { id, limit }
+      );
+      return res.runs ?? [];
+    },
+    []
+  );
+
+  return { list, create, update, remove, trigger, listRuns };
+}

--- a/src/hooks/useGetItems.ts
+++ b/src/hooks/useGetItems.ts
@@ -9,6 +9,7 @@ import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
 import InsightsOutlinedIcon from '@mui/icons-material/InsightsOutlined';
+import CloudDownloadOutlinedIcon from '@mui/icons-material/CloudDownloadOutlined';
 import { NavbarItem } from '@/types/navigation';
 import { SemesterName } from './useSemesterOptions';
 import { useMemo } from 'react';
@@ -68,6 +69,11 @@ export const getNavItems = (userRole: Role): NavbarItem[] => {
           icon: DescriptionOutlinedIcon,
         },
         { label: 'Courses', to: '/admincourses', icon: BookOutlinedIcon },
+        {
+          label: 'Course Fetch',
+          to: '/admin-course-fetch',
+          icon: CloudDownloadOutlinedIcon,
+        },
         // {
         //   label: 'Scheduling',
         //   to: '/scheduling',

--- a/src/types/courseFetch.ts
+++ b/src/types/courseFetch.ts
@@ -1,0 +1,198 @@
+// Types for the configurable course-fetching pipeline.
+//
+// These are shared between the Next.js frontend and Cloud Functions via
+// source duplication (the functions/ codebase has its own `tsconfig`).
+// Keep this file dependency-free so the functions copy can re-import or
+// re-declare the same shapes without pulling in the Next app tree.
+
+export type ProviderId = 'UF';
+
+export type SemesterTermLower = 'spring' | 'summer' | 'fall';
+
+export type RefreshMode =
+  | 'manual'
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'everyNHours';
+
+export type CourseLevel = 'undergraduate' | 'graduate' | 'any';
+
+export type CourseCampus = 'main' | 'online' | 'any';
+
+export type CourseFetchStatus =
+  | 'idle'
+  | 'running'
+  | 'success'
+  | 'partial_success'
+  | 'failed';
+
+// Admin-editable config. Source of truth is `courseFetchConfigs/{id}`.
+export interface CourseFetchConfig {
+  id: string;
+  label: string; // short human-readable name
+  provider: ProviderId;
+  institution: string; // e.g. 'UF'. Kept separate from provider for future multi-tenant use.
+  term: SemesterTermLower;
+  year: number; // e.g. 2026
+  termCode?: string; // optional explicit override; usually derived from provider
+
+  // Filters — empty array / undefined means "no restriction".
+  departments: string[]; // e.g. ['CISE', 'ECE']
+  codePrefixes: string[]; // e.g. ['COP', 'EEL']
+  numberMin?: number; // e.g. 3000 for junior+
+  numberMax?: number;
+  campus: CourseCampus;
+  level: CourseLevel;
+
+  enabled: boolean;
+  refresh: {
+    mode: RefreshMode;
+    // Only used when mode === 'everyNHours'. 1–168 hours.
+    everyHours?: number;
+  };
+
+  // Concurrency for the paginated scrape. Clamped to [1, 16] server-side.
+  concurrency: number;
+
+  // Status / observability fields written by runs.
+  lastRunId?: string;
+  lastStatus?: CourseFetchStatus;
+  lastError?: string;
+  lastSuccessAt?: FirestoreLikeTimestamp | null;
+  lastAttemptAt?: FirestoreLikeTimestamp | null;
+  nextRefreshAt?: FirestoreLikeTimestamp | null;
+
+  createdAt: FirestoreLikeTimestamp;
+  updatedAt: FirestoreLikeTimestamp;
+  createdBy?: string; // uid
+  updatedBy?: string;
+}
+
+// Per-run record. Stored at `courseFetchConfigs/{configId}/runs/{runId}`.
+export interface CourseFetchRun {
+  runId: string;
+  configId: string;
+  startedAt: FirestoreLikeTimestamp;
+  finishedAt?: FirestoreLikeTimestamp | null;
+  status: CourseFetchStatus;
+  rawCount: number;
+  courseCount: number;
+  sectionCount: number;
+  errors: string[];
+  warnings: string[];
+  durationMs?: number;
+  triggeredBy: 'manual' | 'scheduled';
+  triggeredByUid?: string;
+}
+
+// Normalized course in the app-facing catalog.
+export interface CatalogCourse {
+  id: string; // provider:termCode:code, e.g. 'UF:20261:COP3502'
+  provider: ProviderId;
+  institution: string;
+  term: SemesterTermLower;
+  year: number;
+  termCode: string;
+  code: string; // 'COP3502'
+  codeWithSpace: string; // 'COP 3502'
+  department: string; // e.g. 'CISE' (derived from prefix when possible)
+  title: string;
+  description?: string;
+  credits?: string; // e.g. '3' or '1 TO 3'
+  level?: CourseLevel;
+  lastUpdated: FirestoreLikeTimestamp;
+  sourceConfigId: string;
+}
+
+export interface CatalogMeetingTime {
+  day: string; // e.g. 'M' or 'MWF'
+  startTime?: string; // '24h HH:MM' when normalizable
+  endTime?: string;
+  rawTime?: string; // unnormalized fallback
+  building?: string;
+  room?: string;
+  location?: string; // combined building+room
+}
+
+export interface CatalogSection {
+  id: string; // sectionKey, e.g. 'UF:20261:12345'
+  courseId: string;
+  provider: ProviderId;
+  term: SemesterTermLower;
+  year: number;
+  termCode: string;
+  courseCode: string; // attached for easy querying
+  classNumber: string; // e.g. '12345'
+  sectionNumber?: string;
+  instructors: Array<{ name: string; email?: string }>;
+  meetingTimes: CatalogMeetingTime[];
+  enrollmentCap?: number;
+  enrolled?: number;
+  waitlistCap?: number;
+  waitlisted?: number;
+  campus?: string;
+  deliveryMode?: string;
+  lastUpdated: FirestoreLikeTimestamp;
+  sourceConfigId: string;
+}
+
+// --- helpers ---
+
+// We accept either a Firestore Timestamp (when hydrated server-side) or an
+// ISO string / number (when serialized to JSON for the UI). Consumers should
+// normalize via `toDateOrNull` below.
+export type FirestoreLikeTimestamp =
+  | { toDate: () => Date }
+  | { seconds: number; nanoseconds?: number }
+  | string
+  | number
+  | Date
+  | null;
+
+export function toDateOrNull(
+  value: FirestoreLikeTimestamp | undefined
+): Date | null {
+  if (value === undefined || value === null) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === 'string') {
+    const d = new Date(value);
+    return Number.isFinite(d.getTime()) ? d : null;
+  }
+  if (typeof value === 'number') return new Date(value);
+  if (
+    typeof value === 'object' &&
+    'toDate' in value &&
+    typeof value.toDate === 'function'
+  ) {
+    try {
+      return value.toDate();
+    } catch {
+      return null;
+    }
+  }
+  if (typeof value === 'object' && 'seconds' in value) {
+    return new Date((value as { seconds: number }).seconds * 1000);
+  }
+  return null;
+}
+
+// Default config a new admin-created row starts from. Kept here so the
+// UI and server agree on sensible defaults.
+export const DEFAULT_COURSE_FETCH_CONFIG: Omit<
+  CourseFetchConfig,
+  'id' | 'createdAt' | 'updatedAt' | 'createdBy' | 'updatedBy'
+> = {
+  label: 'UF — Spring (CISE)',
+  provider: 'UF',
+  institution: 'UF',
+  term: 'spring',
+  year: new Date().getFullYear(),
+  departments: [],
+  codePrefixes: [],
+  campus: 'any',
+  level: 'any',
+  enabled: false,
+  refresh: { mode: 'manual' },
+  concurrency: 4,
+};


### PR DESCRIPTION
## Summary

Replaces the one-off `UFCourseGrabber.py` script with an app-integrated, editable, periodically-running course-fetching pipeline.

- **Admin-editable configs** in Firestore (`courseFetchConfigs`) covering term/year, departments, code prefixes, number ranges, campus, level, refresh cadence, concurrency, and enable/disable — all validated server-side.
- **Provider-agnostic scraper service** in Cloud Functions under `functions/src/courseFetcher/`. The UF provider mirrors the reference Python script (`category=RES`, `2{YY}{termDigit}` term codes with `spring=1 / summer=5 / fall=8`, stride-50 parallel walks that terminate on `RETRIEVEDROWS=0`). Filters apply post-normalization since ONE.UF doesn't expose them as query params. No session cookies are hardcoded — the provider reads `ONE_UF_COOKIE` from env only if set.
- **Admin UI** at `/admin-course-fetch` (new sidebar entry for admin role): list, create, edit, enable/disable, ▶ run now, and 🕒 run history per config.
- **Cloud Functions endpoints** (all admin-only via bearer-token + `users/{uid}.role === 'admin'`): `listCourseFetchConfigs`, `createCourseFetchConfig`, `updateCourseFetchConfig`, `deleteCourseFetchConfig`, `triggerCourseFetch`, `listCourseFetchRuns`.
- **Scheduled refresh** via `functions.pubsub.schedule('every 30 minutes').onRun(...)`, gated on `enabled === true` and `nextRefreshAt <= now`. Idempotent through a 10-minute `runLeaseUntil` claim inside a Firestore transaction so concurrent invocations don't double-run a config.
- **Storage**: normalized catalog at `catalog/{provider:termCode:code}` with `catalog/.../sections/{provider:termCode:classNumber}` — separate from the existing Excel-upload flow at `semesters/{name}/courses/{id}`, which is untouched.
- **Rules + indexes**: admin-only read on configs and run history, client-writes denied (admin SDK writes only); `catalog` is readable by any authed user. Indexes for the scheduler query, run history, and catalog/sections queries are added.
- **Tests**: pure-logic unit tests via Node's built-in `node:test` runner covering term-code mapping, code-space insertion, 24h time normalization, filtering, dedup, config validation (positive + negative), `computeNextRefreshAt`, and full-pipeline runs against a stubbed `Fetcher` (success, all-workers-fail, non-JSON, and stride-walk verification). Runs via `npm test` in `functions/`.
- **Docs**: `docs/course-fetch-pipeline.md` covers data model, how to add a config, how scheduled refresh works, UF provider specifics, and how to add a new provider/school.

## Security notes

- Admin-only for all config edits and manual runs; scheduled runs use the admin SDK.
- Strict input validation (enum providers/terms/refresh modes, regex for department codes and course prefixes, numeric range clamps, concurrency clamp 1–16) — the UI cannot supply arbitrary URLs or provider parameters.
- Structured errors / warnings surfaced via run records; no credentials or cookies logged; no `os._exit(1)`-style hard exits.
- **Follow-up in main repo**: `UFCourseGrabber.py` has hardcoded `ONEUF_SESSION` + Shibboleth session cookies (lines 34–37). Those should be rotated and scrubbed from git history or replaced with env reads in a separate PR.

## Notable side-effect in this PR

- Added `"root": true` to `.eslintrc.json` so ESLint stops its config lookup at the project root. No-op for non-worktree usage; needed so lint-staged runs cleanly when this repo is checked out as a nested worktree under another copy of itself.

## Assumptions

- The app's read paths still use the existing `semesters/{name}/courses` collection. Cutting those over to `catalog/*` is deliberately out of scope — tracked as a follow-up.
- UF's endpoint shape (field names like `code`, `name`, `sections[].classNumber`, `meetTimes[].meetTimeBegin/End`) is based on the reference Python scraper. Field fallbacks are defensive; missing keys are tolerated, not thrown.

## Test plan

- [ ] `cd functions && npm install && npm test` — pure-logic suite passes
- [ ] `npm install && npm run lint && npm run build` at the repo root — frontend typechecks and lints
- [ ] Deploy functions + rules to a staging project
- [ ] Sign in as admin, open `/admin-course-fetch`, create a UF Fall 2026 config with departments `CISE`, refresh `Manual only`
- [ ] Click ▶ Run now — verify the run record appears in 🕒 history with `success` status and nonzero course/section counts
- [ ] Flip refresh to `Hourly`, enable, wait for `scheduledCourseFetchRefresh` to fire — verify a new run appears, `nextRefreshAt` advances, and `runLeaseUntil` is cleared after completion
- [ ] Verify `catalog/UF:2268:COP3502` and its `sections/` subcollection are written
- [ ] Sign in as faculty/student — confirm the sidebar entry is hidden and endpoints return `403`

🤖 Generated with [Claude Code](https://claude.com/claude-code)