### PR TITLE
fix(course-fetch): memoize useCourseFetchApi object to stop toast spa…

### DIFF
--- a/src/hooks/useCourseFetch.ts
+++ b/src/hooks/useCourseFetch.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { callFunction } from '@/firebase/functions/callFunction';
 import type { CourseFetchConfig, CourseFetchRun } from '@/types/courseFetch';
 
@@ -69,5 +69,10 @@ export function useCourseFetchApi() {
     []
   );
 
-  return { list, create, update, remove, trigger, listRuns };
+  // Memoize the returned object so callers can depend on its identity
+  // (e.g. inside useEffect deps) without triggering re-render loops.
+  return useMemo(
+    () => ({ list, create, update, remove, trigger, listRuns }),
+    [list, create, update, remove, trigger, listRuns]
+  );
 }


### PR DESCRIPTION
…m loop

The hook returned a fresh `{ list, create, ... }` literal every render, so the admin page's `[role, reload]` effect re-fired on every state change (including `setLoading(false)` after a failed call). Wrapping the return in `useMemo` gives the `api` object a stable identity; `reload` is now stable too, and the load-on-mount effect fires once per role change instead of on every re-render — which had turned a single failed call into a non-stop "Failed to fetch" toast loop.