### PR TITLE
fix(admincourses): coerce resolveDepartmentCode null to empty string

### DIFF
--- a/src/app/admincourses/page.tsx
+++ b/src/app/admincourses/page.tsx
@@ -30,7 +30,8 @@ export default function AdminCoursesPage() {
   const { user: currentUser } = useCurrentUser();
   const uploadDeptCode =
     (currentUser.activeDeptId ?? '').toUpperCase() ||
-    resolveDepartmentCode(currentUser.legacyDepartment);
+    resolveDepartmentCode(currentUser.legacyDepartment) ||
+    '';
 
   const isE2E = isE2EMode();
   const [semester, setSemester] = React.useState<string>(currentSemester);


### PR DESCRIPTION
`resolveDepartmentCode` returns `string | null` but `UploadPanel` expects a plain `string` for the department field (matching the original page's usage). The previous `??` fallback still left null as a possibility when `activeDeptId` was empty. Add a trailing `|| ''` so the type narrows to `string` and the empty-department case matches the pre-redesign behavior.