### PR TITLE
feat(course-fetch): merge Departments into Course code prefixes, pull…

### DIFF
--- a/functions/src/courseFetch.ts
+++ b/functions/src/courseFetch.ts
@@ -283,6 +283,7 @@ type PreviewCourseRow = {
   title: string;
   credits?: string;
   department?: string;
+  departmentName?: string;
   sections: PreviewSectionRow[];
 };
 
@@ -378,6 +379,7 @@ export const previewCourseFetch = functions
           title: c.title,
           credits: c.credits,
           department: c.department,
+          departmentName: c.departmentName,
           sections: sectionsByCourse.get(c.code) ?? [],
         }));
 

--- a/functions/src/courseFetcher/__tests__/pipeline.test.ts
+++ b/functions/src/courseFetcher/__tests__/pipeline.test.ts
@@ -78,14 +78,14 @@ function course(
   };
 }
 
-test('filterCourse respects code prefix and department filters', () => {
-  const cop = course('COP3502', { department: 'CISE' });
-  const cda = course('CDA3101', { department: 'CISE' });
-  const mac = course('MAC2311', { department: 'MATH' });
+test('filterCourse matches on code prefix', () => {
+  const cop = course('COP3502');
+  const cda = course('CDA3101');
+  const mac = course('MAC2311');
   assert.equal(filterCourse(cop, { codePrefixes: ['COP'] }), true);
   assert.equal(filterCourse(cda, { codePrefixes: ['COP'] }), false);
-  assert.equal(filterCourse(cop, { departments: ['CISE'] }), true);
-  assert.equal(filterCourse(mac, { departments: ['CISE'] }), false);
+  assert.equal(filterCourse(mac, { codePrefixes: ['COP', 'CDA'] }), false);
+  assert.equal(filterCourse(cda, { codePrefixes: ['COP', 'CDA'] }), true);
 });
 
 test('filterCourse respects numberMin/numberMax', () => {
@@ -196,12 +196,34 @@ test('validateConfigInput rejects bad term / provider / prefixes', () => {
     provider: 'MIT',
     term: 'winter',
     year: 1800,
-    departments: ['cs4life'],
     codePrefixes: ['x'],
     refresh: { mode: 'monthly' },
   });
   assert.equal(res.ok, false);
   assert.ok(!res.ok && res.errors.length >= 4);
+});
+
+test('validateConfigInput folds legacy departments into codePrefixes', () => {
+  const res = validateConfigInput({
+    label: 'legacy',
+    provider: 'UF',
+    term: 'fall',
+    year: 2026,
+    // Old configs may still have `departments` set; valid 2–4 letter codes
+    // get folded into codePrefixes. Entries that don't match the UF prefix
+    // shape (e.g. 'ECE3') are dropped silently so the config still loads.
+    departments: ['EEL', 'CISE', 'ECE3'],
+    codePrefixes: ['COP'],
+    refresh: { mode: 'manual' },
+  });
+  assert.equal(res.ok, true);
+  if (res.ok) {
+    assert.deepEqual([...res.value.codePrefixes].sort(), [
+      'CISE',
+      'COP',
+      'EEL',
+    ]);
+  }
 });
 
 test('validateConfigInput enforces everyHours range for everyNHours', () => {
@@ -365,7 +387,7 @@ test('fetchCoursesForConfig marks failed when every worker errors', async () => 
       institution: 'UF',
       term: 'spring',
       year: 2026,
-      filters: { departments: ['CISE'] },
+      filters: { codePrefixes: ['COP'] },
       concurrency: 1,
     },
     { fetcher: stub }

--- a/functions/src/courseFetcher/normalize.ts
+++ b/functions/src/courseFetcher/normalize.ts
@@ -112,13 +112,6 @@ export function filterCourse(
     if (!f.codePrefixes.some((p) => prefix === p.toUpperCase())) return false;
   }
 
-  if (f.departments && f.departments.length > 0) {
-    const dept = (
-      course.department ?? departmentFromCode(course.code)
-    ).toUpperCase();
-    if (!f.departments.some((d) => dept === d.toUpperCase())) return false;
-  }
-
   // Number range filter — pull trailing digits from the code.
   if (f.numberMin != null || f.numberMax != null) {
     const digits = course.code.match(/(\d{3,4})/);

--- a/functions/src/courseFetcher/providers/uf.ts
+++ b/functions/src/courseFetcher/providers/uf.ts
@@ -162,7 +162,18 @@ function normalizeCourseRow(row: unknown): {
   const description = str(pick(row, 'description'));
   const credits =
     str(pick(row, 'openCredits')) ?? str(pick(row, 'credits')) ?? undefined;
-  const dept = str(pick(row, 'deptName')) ?? str(pick(row, 'department'));
+
+  // ONE.UF does not place deptName on the course row — it lives on each
+  // section. All sections of a course share the same department, so the
+  // first section's deptName is authoritative for the course.
+  const rawSectionsForDept = pick(row, 'sections');
+  const firstSection = Array.isArray(rawSectionsForDept)
+    ? rawSectionsForDept[0]
+    : undefined;
+  const departmentName =
+    str(pick(row, 'deptName')) ??
+    str(pick(row, 'department')) ??
+    str(pick(firstSection, 'deptName'));
 
   const course: NormalizedCourse = {
     code,
@@ -170,7 +181,7 @@ function normalizeCourseRow(row: unknown): {
     title,
     description,
     credits,
-    department: dept,
+    departmentName,
   };
 
   const rawSections = pick(row, 'sections');

--- a/functions/src/courseFetcher/runner.ts
+++ b/functions/src/courseFetcher/runner.ts
@@ -78,6 +78,7 @@ function buildSemesterCourseDoc(
     title: course.title,
     credits: course.credits ?? '',
     department: (course.department ?? '').toUpperCase(),
+    department_name: course.departmentName ?? '',
     professor_names: instructorNames.join(', '),
     professor_emails: instructorEmails,
     enrollment_cap:

--- a/functions/src/courseFetcher/types.ts
+++ b/functions/src/courseFetcher/types.ts
@@ -8,7 +8,6 @@ export type CourseCampus = 'main' | 'online' | 'any';
 export type FetchStatus = 'success' | 'partial_success' | 'failed';
 
 export interface FilterOptions {
-  departments?: string[];
   codePrefixes?: string[];
   numberMin?: number;
   numberMax?: number;
@@ -32,7 +31,8 @@ export interface NormalizedCourse {
   code: string; // 'COP3502'
   codeWithSpace: string; // 'COP 3502'
   title: string;
-  department?: string;
+  department?: string; // short code prefix, e.g. 'COP'
+  departmentName?: string; // human-readable provider name, e.g. 'Computer & Information Science & Engineering'
   description?: string;
   credits?: string;
   level?: CourseLevel;

--- a/functions/src/courseFetcher/validation.ts
+++ b/functions/src/courseFetcher/validation.ts
@@ -29,7 +29,6 @@ export type ValidatedConfig = {
   term: SemesterTermLower;
   year: number;
   termCode?: string;
-  departments: string[];
   codePrefixes: string[];
   numberMin?: number;
   numberMax?: number;
@@ -58,7 +57,6 @@ const REFRESH_MODES = [
   'weekly',
   'everyNHours',
 ] as const;
-const DEPT_CODE = /^[A-Z]{2,6}$/;
 const COURSE_PREFIX = /^[A-Z]{2,4}$/;
 
 function isNonEmptyString(v: unknown): v is string {
@@ -143,18 +141,28 @@ export function validateConfigInput(input: ConfigInput): ValidationResult {
     }
   }
 
-  const departments = toStringArray(
-    input.departments,
-    DEPT_CODE,
-    'departments',
-    errors
-  );
+  // The Departments and Course code prefixes fields were merged into a single
+  // codePrefixes list — on UF both compared against the same 2–4 letter code
+  // prefix. We still accept `departments` from legacy stored configs and fold
+  // any valid 2–4 letter codes into the codePrefixes union. Entries that
+  // don't match UF's prefix shape (e.g. 'ECE3') are dropped silently rather
+  // than erroring so a stored config can still load and be re-saved.
   const codePrefixes = toStringArray(
     input.codePrefixes,
     COURSE_PREFIX,
     'codePrefixes',
     errors
   );
+  const legacyDeptErrors: string[] = [];
+  const legacyDepts = toStringArray(
+    input.departments,
+    COURSE_PREFIX,
+    'departments',
+    legacyDeptErrors
+  );
+  for (const d of legacyDepts) {
+    if (!codePrefixes.includes(d)) codePrefixes.push(d);
+  }
 
   let numberMin: number | undefined;
   let numberMax: number | undefined;
@@ -229,7 +237,6 @@ export function validateConfigInput(input: ConfigInput): ValidationResult {
       term: term as SemesterTermLower,
       year,
       termCode,
-      departments,
       codePrefixes,
       numberMin,
       numberMax,
@@ -255,7 +262,6 @@ export function toConfigSnapshot(
     year: v.year,
     termCode: v.termCode,
     filters: {
-      departments: v.departments,
       codePrefixes: v.codePrefixes,
       numberMin: v.numberMin,
       numberMax: v.numberMax,

--- a/src/app/admincourses/AutoFetchPanel.tsx
+++ b/src/app/admincourses/AutoFetchPanel.tsx
@@ -85,7 +85,6 @@ function refreshLabel(refresh: CourseFetchConfig['refresh']): string {
 
 function filterSummary(c: CourseFetchConfig): string {
   const parts: string[] = [];
-  if (c.departments.length > 0) parts.push(c.departments.join(', '));
   if (c.codePrefixes.length > 0) parts.push(c.codePrefixes.join(', '));
   if (c.numberMin != null || c.numberMax != null) {
     parts.push(`${c.numberMin ?? 0}–${c.numberMax ?? 9999}`);

--- a/src/app/admincourses/ConfigForm.tsx
+++ b/src/app/admincourses/ConfigForm.tsx
@@ -58,7 +58,6 @@ function draftFromInitial(
     term: initial.term,
     year: initial.year,
     termCode: initial.termCode,
-    departments: initial.departments ?? [],
     codePrefixes: initial.codePrefixes ?? [],
     numberMin: initial.numberMin,
     numberMax: initial.numberMax,
@@ -88,9 +87,6 @@ export default function ConfigForm({
   submitting,
 }: ConfigFormProps) {
   const [draft, setDraft] = React.useState<Draft>(draftFromInitial(initial));
-  const [departmentsRaw, setDepartmentsRaw] = React.useState(
-    joinCsv(initial?.departments)
-  );
   const [prefixesRaw, setPrefixesRaw] = React.useState(
     joinCsv(initial?.codePrefixes)
   );
@@ -98,7 +94,6 @@ export default function ConfigForm({
 
   React.useEffect(() => {
     setDraft(draftFromInitial(initial));
-    setDepartmentsRaw(joinCsv(initial?.departments));
     setPrefixesRaw(joinCsv(initial?.codePrefixes));
     setErr(null);
   }, [initial, open]);
@@ -107,7 +102,6 @@ export default function ConfigForm({
     setErr(null);
     const payload: Draft = {
       ...draft,
-      departments: parseCsv(departmentsRaw),
       codePrefixes: parseCsv(prefixesRaw),
     };
     try {
@@ -202,15 +196,8 @@ export default function ConfigForm({
             />
           </Stack>
           <TextField
-            label="Departments (comma-separated)"
-            helperText="e.g. CISE, ECE. Leave empty for all."
-            value={departmentsRaw}
-            onChange={(e) => setDepartmentsRaw(e.target.value)}
-            fullWidth
-          />
-          <TextField
             label="Course code prefixes (comma-separated)"
-            helperText="e.g. COP, EEL. Leave empty for all."
+            helperText="UF 2–4 letter prefix on the course code. CISE: COP, CAP, CIS, CEN, CDA, CNT. ECE: EEL, EEE, EGN. Leave empty for all."
             value={prefixesRaw}
             onChange={(e) => setPrefixesRaw(e.target.value)}
             fullWidth

--- a/src/types/courseFetch.ts
+++ b/src/types/courseFetch.ts
@@ -38,8 +38,8 @@ export interface CourseFetchConfig {
   termCode?: string; // optional explicit override; usually derived from provider
 
   // Filters — empty array / undefined means "no restriction".
-  departments: string[]; // e.g. ['CISE', 'ECE']
-  codePrefixes: string[]; // e.g. ['COP', 'EEL']
+  // codePrefixes matches UF 2–4 letter course prefixes (e.g. 'COP', 'EEL').
+  codePrefixes: string[];
   numberMin?: number; // e.g. 3000 for junior+
   numberMax?: number;
   campus: CourseCampus;
@@ -164,7 +164,8 @@ export interface PreviewCourse {
   codeWithSpace: string;
   title: string;
   credits?: string;
-  department?: string;
+  department?: string; // short code prefix
+  departmentName?: string; // full provider-supplied name
   sections: PreviewSection[];
 }
 
@@ -234,7 +235,6 @@ export const DEFAULT_COURSE_FETCH_CONFIG: Omit<
   institution: 'UF',
   term: 'spring',
   year: new Date().getFullYear(),
-  departments: [],
   codePrefixes: [],
   campus: 'any',
   level: 'any',


### PR DESCRIPTION
… UF deptName

The admin UI had two filter fields that did the same thing on UF — both compared against the course's 2–4 letter code prefix, because ONE.UF never exposes deptName on the course row. The "Departments" field's "e.g. CISE, ECE" placeholder misled admins into typing umbrella names that could never match, producing empty preview results.

Collapse into a single Course code prefixes field with honest helper text. Accept legacy stored `departments` arrays by folding valid 2–4 letter entries into codePrefixes during validation so existing configs keep loading.

Also pull ONE.UF's deptName up from the first section into a new `departmentName` on NormalizedCourse, exposed through the preview response and written to Firestore as `department_name` alongside the existing short-code `department` field.