### PR TITLE
feat(course-fetch): always-preview + cancellable runs with live phase

### DIFF
--- a/functions/src/courseFetch.ts
+++ b/functions/src/courseFetch.ts
@@ -421,6 +421,64 @@ export const previewCourseFetch = functions
     }
   });
 
+// --- Cancel a running run ---
+//
+// Cooperative: flips `cancelRequested` on the run doc. The runner polls this
+// flag between provider pages and between batch commits and bails out
+// cleanly, writing a 'cancelled' terminal state. Idempotent — calling twice
+// on the same run is a no-op after the first flip.
+
+export const cancelCourseFetchRun = functions.https.onRequest(
+  async (req: Request, res: Response) => {
+    setCors(req, res);
+    if (!handleMethod(req, res)) return;
+    const caller = await verifyAuth(req, res);
+    if (!caller) return;
+    if (!(await ensureAdmin(caller.uid, res))) return;
+
+    try {
+      const body = asRecord(req.body);
+      const configId = readString(body, 'configId');
+      const runId = readString(body, 'runId');
+      if (!configId || !runId) {
+        fail(res, 'Missing configId or runId');
+        return;
+      }
+      const runRef = db
+        .collection('courseFetchConfigs')
+        .doc(configId)
+        .collection('runs')
+        .doc(runId);
+      const snap = await runRef.get();
+      if (!snap.exists) {
+        fail(res, 'Run not found', 404);
+        return;
+      }
+      const data = snap.data() ?? {};
+      if (data.status !== 'running') {
+        // Already terminal — nothing to cancel. Return 200 so the UI treats
+        // this as a no-op rather than an error.
+        res
+          .status(200)
+          .json({ configId, runId, cancelled: false, alreadyTerminal: true });
+        return;
+      }
+      await runRef.set(
+        {
+          cancelRequested: true,
+          cancelRequestedBy: caller.uid,
+          cancelRequestedAt: now(),
+        },
+        { merge: true }
+      );
+      res.status(200).json({ configId, runId, cancelled: true });
+    } catch (error) {
+      console.error('cancelCourseFetchRun failed:', error);
+      fail(res, 'Failed to cancel run', 500);
+    }
+  }
+);
+
 // --- Run history ---
 
 export const listCourseFetchRuns = functions.https.onRequest(

--- a/functions/src/courseFetcher/__tests__/pipeline.test.ts
+++ b/functions/src/courseFetcher/__tests__/pipeline.test.ts
@@ -396,6 +396,59 @@ test('fetchCoursesForConfig marks failed when every worker errors', async () => 
   assert.ok(result.errors.length > 0);
 });
 
+test('fetchCoursesForConfig short-circuits when checkCancel fires mid-walk', async () => {
+  // Provider returns one page with real rows, then would normally continue.
+  // We flip cancel to true after the first page is fetched, so the worker
+  // should bail before issuing a second request. The result is marked
+  // 'cancelled' and its rows reflect only pre-cancel pages.
+  let cancelled = false;
+  let fetchCalls = 0;
+  const firstPage = ufResponse([
+    {
+      code: 'COP3502',
+      name: 'Programming Fundamentals 1',
+      sections: [
+        {
+          classNumber: '11111',
+          number: '001',
+          instructors: [{ name: 'A. Alpha' }],
+          meetTimes: [],
+        },
+      ],
+    },
+  ]);
+  const stub: Fetcher = async () => {
+    fetchCalls++;
+    // Flip cancel after the first successful fetch so the *next* loop
+    // iteration bails. The worker's cancel probe runs before buildUrl.
+    cancelled = true;
+    return new Response(JSON.stringify(firstPage), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  const result = await fetchCoursesForConfig(
+    {
+      id: 'cfg-cancel',
+      provider: 'UF',
+      institution: 'UF',
+      term: 'fall',
+      year: 2026,
+      filters: { codePrefixes: ['COP'] },
+      concurrency: 1,
+    },
+    { fetcher: stub, checkCancel: async () => cancelled }
+  );
+
+  assert.equal(result.status, 'cancelled');
+  assert.equal(result.cancelled, true);
+  // One pre-cancel fetch landed; no second fetch after cancel flipped.
+  assert.equal(fetchCalls, 1);
+  assert.equal(result.courses.length, 1);
+  assert.equal(result.sections.length, 1);
+});
+
 test('fetchCoursesForConfig handles non-JSON gracefully', async () => {
   const stub: Fetcher = async () =>
     new Response('<html>oops</html>', {

--- a/functions/src/courseFetcher/pipeline.ts
+++ b/functions/src/courseFetcher/pipeline.ts
@@ -10,6 +10,7 @@ import {
 } from './normalize';
 import { ufProvider } from './providers/uf';
 import type {
+  CancelCheck,
   ConfigSnapshot,
   Fetcher,
   FetchResult,
@@ -29,7 +30,7 @@ export function getProvider(id: ProviderId): Provider {
 
 export async function fetchCoursesForConfig(
   config: ConfigSnapshot,
-  options: { fetcher?: Fetcher } = {}
+  options: { fetcher?: Fetcher; checkCancel?: CancelCheck } = {}
 ): Promise<FetchResult> {
   const provider = getProvider(config.provider);
   const termCode =
@@ -42,6 +43,7 @@ export async function fetchCoursesForConfig(
       config,
       termCode,
       fetcher: options.fetcher,
+      checkCancel: options.checkCancel,
     });
   } catch (err) {
     return {
@@ -54,6 +56,7 @@ export async function fetchCoursesForConfig(
     };
   }
 
+  const cancelled = providerResult.cancelled === true;
   const rawCount = providerResult.rawCount;
 
   const filtered = providerResult.courses
@@ -75,12 +78,13 @@ export async function fetchCoursesForConfig(
   const errors = providerResult.errors ?? [];
   const warnings = providerResult.warnings ?? [];
 
-  const status: FetchResult['status'] =
-    errors.length === 0
-      ? 'success'
-      : dedupedCourses.length > 0
-      ? 'partial_success'
-      : 'failed';
+  const status: FetchResult['status'] = cancelled
+    ? 'cancelled'
+    : errors.length === 0
+    ? 'success'
+    : dedupedCourses.length > 0
+    ? 'partial_success'
+    : 'failed';
 
   return {
     status,
@@ -90,5 +94,6 @@ export async function fetchCoursesForConfig(
     errors,
     warnings,
     providerMeta: { termCode },
+    ...(cancelled ? { cancelled: true } : {}),
   };
 }

--- a/functions/src/courseFetcher/providers/uf.ts
+++ b/functions/src/courseFetcher/providers/uf.ts
@@ -17,6 +17,7 @@
 // read from `process.env.ONE_UF_COOKIE` at runtime only — never hardcoded.
 
 import type {
+  CancelCheck,
   ConfigSnapshot,
   Fetcher,
   NormalizedCourse,
@@ -268,19 +269,27 @@ function normalizeSectionRow(
 // One worker walks last-control-number = start, start+stride, start+2*stride, ...
 // stopping when its response reports RETRIEVEDROWS == 0. Each worker records
 // errors independently so a single shard failing does not abort the run.
+// If checkCancel returns true between pages, the worker returns what it has
+// so far and sets cancelled=true.
 async function walkStride(params: {
   termCode: string;
   start: number;
   stride: number;
   fetcher: Fetcher;
-}): Promise<{ rawCourses: unknown[]; errors: string[] }> {
-  const { termCode, start, stride, fetcher } = params;
+  checkCancel?: CancelCheck;
+}): Promise<{ rawCourses: unknown[]; errors: string[]; cancelled: boolean }> {
+  const { termCode, start, stride, fetcher, checkCancel } = params;
   const rawCourses: unknown[] = [];
   const errors: string[] = [];
   let last = start;
+  let cancelled = false;
   // Safety cap: 400 * stride ~= 20k control numbers per worker, far above
   // any real term size. Prevents infinite loops on provider bugs.
   for (let i = 0; i < 400; i++) {
+    if (checkCancel && (await checkCancel())) {
+      cancelled = true;
+      break;
+    }
     const url = buildUrl(termCode, last);
     let page: UFPage;
     try {
@@ -297,13 +306,13 @@ async function walkStride(params: {
     if (page.rawCourses.length > 0) rawCourses.push(...page.rawCourses);
     last += stride;
   }
-  return { rawCourses, errors };
+  return { rawCourses, errors, cancelled };
 }
 
 export const ufProvider: Provider = {
   id: 'UF',
   resolveTermCode: ufTermCode,
-  async fetch({ config, termCode, fetcher }) {
+  async fetch({ config, termCode, fetcher, checkCancel }) {
     const use = fetcher ?? (globalThis.fetch as Fetcher);
     const warnings: string[] = [];
     const errors: string[] = [];
@@ -316,8 +325,9 @@ export const ufProvider: Provider = {
     // department/prefix parameters.
     const workerCount = Math.max(1, Math.min(config.concurrency, 16));
     const stride = PAGE_SIZE * workerCount;
-    const workers: Array<Promise<{ rawCourses: unknown[]; errors: string[] }>> =
-      [];
+    const workers: Array<
+      Promise<{ rawCourses: unknown[]; errors: string[]; cancelled: boolean }>
+    > = [];
     for (let i = 0; i < workerCount; i++) {
       workers.push(
         walkStride({
@@ -325,10 +335,12 @@ export const ufProvider: Provider = {
           start: PAGE_SIZE * i,
           stride,
           fetcher: use,
+          checkCancel,
         })
       );
     }
     const results = await Promise.all(workers);
+    const cancelled = results.some((r) => r.cancelled);
     for (const r of results) {
       if (r.errors.length) errors.push(...r.errors);
       for (const row of r.rawCourses) {
@@ -349,6 +361,7 @@ export const ufProvider: Provider = {
       sections: normalizedSections,
       errors,
       warnings,
+      ...(cancelled ? { cancelled: true } : {}),
     };
   },
 };

--- a/functions/src/courseFetcher/runner.ts
+++ b/functions/src/courseFetcher/runner.ts
@@ -12,6 +12,7 @@ import {
   type ValidatedConfig,
 } from './validation';
 import type {
+  CancelCheck,
   FetchResult,
   NormalizedCourse,
   NormalizedMeetingTime,
@@ -128,8 +129,9 @@ async function commitCoursesAndSections(
   provider: string,
   config: ValidatedConfig,
   result: FetchResult,
-  includeCourses?: string[]
-): Promise<void> {
+  includeCourses?: string[],
+  checkCancel?: CancelCheck
+): Promise<{ cancelled: boolean }> {
   const catalog = db.collection('catalog');
   const termCode =
     (result.providerMeta &&
@@ -168,13 +170,18 @@ async function commitCoursesAndSections(
   type Op = () => void;
   let batch = db.batch();
   let ops = 0;
+  let cancelled = false;
   const flush = async () => {
     if (ops === 0) return;
     await batch.commit();
     batch = db.batch();
     ops = 0;
+    if (checkCancel && (await checkCancel())) {
+      cancelled = true;
+    }
   };
   const add = async (op: Op) => {
+    if (cancelled) return;
     op();
     ops++;
     if (ops >= BATCH_LIMIT) await flush();
@@ -191,6 +198,7 @@ async function commitCoursesAndSections(
   );
 
   for (const course of coursesToWrite) {
+    if (cancelled) break;
     // 1) Cross-term catalog doc — audit/reuse across configs.
     const catalogId = `${prefix}:${course.code}`;
     const catalogRef = catalog.doc(catalogId);
@@ -230,6 +238,7 @@ async function commitCoursesAndSections(
   // Also write per-section catalog rows (pure audit, independent of the
   // legacy semester layout).
   for (const section of sectionsToWrite) {
+    if (cancelled) break;
     const parentId = `${prefix}:${section.courseCode}`;
     const sectionId = `${prefix}:${section.classNumber}`;
     const ref = catalog.doc(parentId).collection('sections').doc(sectionId);
@@ -251,6 +260,7 @@ async function commitCoursesAndSections(
   }
 
   await flush();
+  return { cancelled };
 }
 
 export async function runAndPersist(ctx: RunContext): Promise<RunOutcome> {
@@ -269,11 +279,13 @@ export async function runAndPersist(ctx: RunContext): Promise<RunOutcome> {
     configId,
     startedAt: now(),
     status: 'running',
+    phase: 'fetching',
     rawCount: 0,
     courseCount: 0,
     sectionCount: 0,
     errors: [],
     warnings: [],
+    cancelRequested: false,
     triggeredBy,
     ...(triggeredByUid ? { triggeredByUid } : {}),
   });
@@ -287,10 +299,22 @@ export async function runAndPersist(ctx: RunContext): Promise<RunOutcome> {
     { merge: true }
   );
 
+  // Cooperative cancellation probe. Reads the run doc; returns true once an
+  // admin has hit Cancel via cancelCourseFetchRun. One extra read per page /
+  // batch is cheap at UF scale.
+  const checkCancel: CancelCheck = async () => {
+    try {
+      const snap = await runRef.get();
+      return snap.exists && snap.data()?.cancelRequested === true;
+    } catch {
+      return false;
+    }
+  };
+
   const snapshot = toConfigSnapshot(configId, config);
   let result: FetchResult;
   try {
-    result = await fetchCoursesForConfig(snapshot);
+    result = await fetchCoursesForConfig(snapshot, { checkCancel });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const finishedAt = new Date();
@@ -327,19 +351,35 @@ export async function runAndPersist(ctx: RunContext): Promise<RunOutcome> {
     };
   }
 
-  try {
-    await commitCoursesAndSections(
-      db,
-      configId,
-      config.provider,
-      config,
-      result,
-      includeCourses
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    result.status = result.status === 'failed' ? 'failed' : 'partial_success';
-    result.errors.push(`persist: ${message}`);
+  // If the provider loop was cancelled, skip persist entirely. No partial
+  // writes, no lastSuccessAt bump; nextRefreshAt still advances so a cron
+  // doesn't retry-storm on the next tick.
+  let persistCancelled = false;
+  if (result.status === 'cancelled' || result.cancelled) {
+    // fall through to terminal block
+  } else {
+    await runRef.set({ phase: 'writing' }, { merge: true });
+    try {
+      const commitRes = await commitCoursesAndSections(
+        db,
+        configId,
+        config.provider,
+        config,
+        result,
+        includeCourses,
+        checkCancel
+      );
+      persistCancelled = commitRes.cancelled;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      result.status = result.status === 'failed' ? 'failed' : 'partial_success';
+      result.errors.push(`persist: ${message}`);
+    }
+  }
+
+  const cancelled = result.status === 'cancelled' || persistCancelled;
+  if (cancelled) {
+    result.status = 'cancelled';
   }
 
   const finishedAt = new Date();
@@ -361,13 +401,32 @@ export async function runAndPersist(ctx: RunContext): Promise<RunOutcome> {
       ).length
     : result.sections.length;
 
+  // Pull the cancelling uid off the run doc (if any) so the warning message
+  // names the admin who hit Cancel. Best-effort only.
+  let cancelWho: string | undefined;
+  if (cancelled) {
+    try {
+      const snap = await runRef.get();
+      const data = snap.data();
+      if (typeof data?.cancelRequestedBy === 'string') {
+        cancelWho = data.cancelRequestedBy;
+      }
+    } catch {
+      // ignore
+    }
+    const phase = persistCancelled ? 'writing' : 'fetching';
+    result.warnings.unshift(
+      `run cancelled${cancelWho ? ` by ${cancelWho}` : ''} during ${phase}`
+    );
+  }
+
   await runRef.set(
     {
       finishedAt: now(),
       status: result.status,
       rawCount: result.rawCount,
-      courseCount: persistedCourseCount,
-      sectionCount: persistedSectionCount,
+      courseCount: cancelled && !persistCancelled ? 0 : persistedCourseCount,
+      sectionCount: cancelled && !persistCancelled ? 0 : persistedSectionCount,
       errors: result.errors.slice(0, 50),
       warnings: result.warnings.slice(0, 50),
       durationMs,
@@ -382,8 +441,12 @@ export async function runAndPersist(ctx: RunContext): Promise<RunOutcome> {
     .set(
       {
         lastStatus: result.status,
-        lastError: result.errors[0] ?? admin.firestore.FieldValue.delete(),
-        lastSuccessAt: result.status === 'failed' ? undefined : now(),
+        lastError:
+          cancelled || !result.errors[0]
+            ? admin.firestore.FieldValue.delete()
+            : result.errors[0],
+        lastSuccessAt:
+          result.status === 'failed' || cancelled ? undefined : now(),
         nextRefreshAt: computeNextRefreshAt(config.refresh, finishedAt),
       },
       { merge: true }
@@ -393,8 +456,8 @@ export async function runAndPersist(ctx: RunContext): Promise<RunOutcome> {
     runId,
     status: result.status,
     rawCount: result.rawCount,
-    courseCount: persistedCourseCount,
-    sectionCount: persistedSectionCount,
+    courseCount: cancelled && !persistCancelled ? 0 : persistedCourseCount,
+    sectionCount: cancelled && !persistCancelled ? 0 : persistedSectionCount,
     durationMs,
     errors: result.errors,
     warnings: result.warnings,

--- a/functions/src/courseFetcher/types.ts
+++ b/functions/src/courseFetcher/types.ts
@@ -5,7 +5,16 @@ export type ProviderId = 'UF';
 export type SemesterTermLower = 'spring' | 'summer' | 'fall';
 export type CourseLevel = 'undergraduate' | 'graduate' | 'any';
 export type CourseCampus = 'main' | 'online' | 'any';
-export type FetchStatus = 'success' | 'partial_success' | 'failed';
+export type FetchStatus =
+  | 'success'
+  | 'partial_success'
+  | 'failed'
+  | 'cancelled';
+
+// Cooperative cancellation probe. Pipeline/provider code awaits this at
+// natural checkpoints (between pages, before persist, between batches) and
+// bails out cleanly if it resolves true. Returning false means "keep going".
+export type CancelCheck = () => Promise<boolean>;
 
 export interface FilterOptions {
   codePrefixes?: string[];
@@ -70,6 +79,7 @@ export interface FetchResult {
   errors: string[];
   warnings: string[];
   providerMeta?: Record<string, unknown>;
+  cancelled?: boolean;
 }
 
 export interface Provider {
@@ -82,7 +92,8 @@ export interface Provider {
     config: ConfigSnapshot;
     termCode: string;
     fetcher?: Fetcher;
-  }): Promise<Omit<FetchResult, 'status'>>;
+    checkCancel?: CancelCheck;
+  }): Promise<Omit<FetchResult, 'status'> & { cancelled?: boolean }>;
 }
 
 // Abstracted so tests can inject a deterministic implementation without
@@ -92,5 +103,5 @@ export type Fetcher = (url: string, init?: RequestInit) => Promise<Response>;
 // Public entry point the Cloud Function calls.
 export type FetchCoursesForConfig = (
   config: ConfigSnapshot,
-  options?: { fetcher?: Fetcher }
+  options?: { fetcher?: Fetcher; checkCancel?: CancelCheck }
 ) => Promise<FetchResult>;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -621,5 +621,6 @@ export {
   triggerCourseFetch,
   previewCourseFetch,
   listCourseFetchRuns,
+  cancelCourseFetchRun,
   scheduledCourseFetchRefresh,
 } from './courseFetch';

--- a/src/app/admincourses/AutoFetchPanel.tsx
+++ b/src/app/admincourses/AutoFetchPanel.tsx
@@ -14,8 +14,8 @@ import {
   Typography,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
+import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/DeleteOutline';
 import HistoryIcon from '@mui/icons-material/History';
@@ -26,8 +26,14 @@ import ScheduleOutlinedIcon from '@mui/icons-material/ScheduleOutlined';
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { toast } from 'react-hot-toast';
+import firebase from '@/firebase/firebase_config';
+import 'firebase/firestore';
 import { useCourseFetchApi } from '@/hooks/useCourseFetch';
-import type { CourseFetchConfig, CoursePreview } from '@/types/courseFetch';
+import type {
+  CourseFetchConfig,
+  CourseFetchPhase,
+  CoursePreview,
+} from '@/types/courseFetch';
 import { toDateOrNull } from '@/types/courseFetch';
 import ConfigForm, { semesterNameFromTermYear } from './ConfigForm';
 import RunHistoryDialog from './RunHistoryDialog';
@@ -170,14 +176,21 @@ function Arrow() {
 
 // --- Config card ---
 
+interface ActiveRunState {
+  runId: string;
+  phase?: CourseFetchPhase;
+  cancelling?: boolean;
+  triggeredBy?: 'manual' | 'scheduled';
+}
+
 function ConfigCard(props: {
   config: CourseFetchConfig;
   currentSemester: string;
-  running: boolean;
+  activeRun: ActiveRunState | null;
   previewing: boolean;
   onToggle: (enabled: boolean) => void;
-  onRun: () => void;
   onPreview: () => void;
+  onCancel: () => void;
   onEdit: () => void;
   onDelete: () => void;
   onHistory: () => void;
@@ -308,56 +321,80 @@ function ConfigCard(props: {
             'Never run'
           )}
         </Typography>
-        <Stack direction="row" spacing={0.5}>
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={
-              props.previewing ? (
-                <CircularProgress size={14} />
-              ) : (
-                <VisibilityOutlinedIcon fontSize="small" />
-              )
-            }
-            disabled={props.previewing || props.running}
-            onClick={props.onPreview}
-            sx={{
-              textTransform: 'none',
-              borderColor: 'rgba(86,46,186,0.4)',
-              color: PURPLE,
-              '&:hover': {
-                borderColor: PURPLE,
-                bgcolor: 'rgba(86,46,186,0.04)',
-              },
-            }}
-          >
-            Preview
-          </Button>
-          <Button
-            size="small"
-            variant="contained"
-            disableElevation
-            startIcon={
-              props.running ? (
-                <CircularProgress size={14} color="inherit" />
-              ) : (
-                <PlayArrowIcon fontSize="small" />
-              )
-            }
-            disabled={props.running || props.previewing}
-            onClick={props.onRun}
-            sx={{
-              textTransform: 'none',
-              bgcolor: PURPLE,
-              '&:hover': { bgcolor: '#4524a0' },
-            }}
-          >
-            Run now
-          </Button>
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          {props.activeRun ? (
+            <>
+              <Chip
+                size="small"
+                icon={<CircularProgress size={12} thickness={5} />}
+                label={
+                  props.activeRun.phase === 'writing' ? 'Writing…' : 'Fetching…'
+                }
+                sx={{
+                  bgcolor: 'rgba(86,46,186,0.08)',
+                  color: PURPLE,
+                  fontWeight: 600,
+                  '& .MuiChip-icon': { color: PURPLE, ml: '6px' },
+                }}
+              />
+              {props.activeRun.triggeredBy === 'scheduled' && (
+                <Chip
+                  size="small"
+                  label="scheduled"
+                  variant="outlined"
+                  sx={{ borderColor: 'divider', color: 'text.secondary' }}
+                />
+              )}
+              <Button
+                size="small"
+                variant="outlined"
+                color="error"
+                startIcon={
+                  props.activeRun.cancelling ? (
+                    <CircularProgress size={14} color="inherit" />
+                  ) : (
+                    <StopCircleOutlinedIcon fontSize="small" />
+                  )
+                }
+                disabled={props.activeRun.cancelling}
+                onClick={props.onCancel}
+                sx={{ textTransform: 'none' }}
+              >
+                {props.activeRun.cancelling ? 'Cancelling…' : 'Cancel run'}
+              </Button>
+            </>
+          ) : (
+            <Button
+              size="small"
+              variant="contained"
+              disableElevation
+              startIcon={
+                props.previewing ? (
+                  <CircularProgress size={14} color="inherit" />
+                ) : (
+                  <VisibilityOutlinedIcon fontSize="small" />
+                )
+              }
+              disabled={props.previewing}
+              onClick={props.onPreview}
+              sx={{
+                textTransform: 'none',
+                bgcolor: PURPLE,
+                '&:hover': { bgcolor: '#4524a0' },
+              }}
+            >
+              Run…
+            </Button>
+          )}
           <IconButton size="small" onClick={props.onHistory} title="History">
             <HistoryIcon fontSize="small" />
           </IconButton>
-          <IconButton size="small" onClick={props.onEdit} title="Edit">
+          <IconButton
+            size="small"
+            onClick={props.onEdit}
+            title="Edit"
+            disabled={!!props.activeRun}
+          >
             <EditIcon fontSize="small" />
           </IconButton>
           <IconButton
@@ -365,6 +402,7 @@ function ConfigCard(props: {
             color="error"
             onClick={props.onDelete}
             title="Delete"
+            disabled={!!props.activeRun}
           >
             <DeleteIcon fontSize="small" />
           </IconButton>
@@ -390,7 +428,9 @@ export default function AutoFetchPanel({
   const [formOpen, setFormOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<CourseFetchConfig | null>(null);
   const [submitting, setSubmitting] = React.useState(false);
-  const [runningId, setRunningId] = React.useState<string | null>(null);
+  const [activeRuns, setActiveRuns] = React.useState<
+    Record<string, ActiveRunState>
+  >({});
   const [historyId, setHistoryId] = React.useState<string | null>(null);
   const [previewConfig, setPreviewConfig] =
     React.useState<CourseFetchConfig | null>(null);
@@ -400,6 +440,16 @@ export default function AutoFetchPanel({
     null
   );
 
+  // Track which runIds have already emitted a terminal toast so re-fires of
+  // the same terminal snapshot (or stale historical runs loaded at mount)
+  // don't spam the admin.
+  const toastedRunIdsRef = React.useRef<Set<string>>(new Set());
+  // Per-runId cleanup functions for run-doc subscriptions. Keyed by runId so
+  // a new run on the same config can coexist with a terminal-cleanup race.
+  const runSubsRef = React.useRef<Map<string, () => void>>(new Map());
+
+  // Manual reload kept for the Refresh button; the collection snapshot below
+  // also keeps configs live, so this is primarily for explicit user action.
   const reload = React.useCallback(async () => {
     setLoading(true);
     setLoadError(null);
@@ -414,9 +464,140 @@ export default function AutoFetchPanel({
     }
   }, [api]);
 
+  // Live listener on the configs collection — picks up cron-initiated runs,
+  // live status transitions, and the `lastRunId` bump on Apply without
+  // requiring a manual refresh.
   React.useEffect(() => {
-    reload();
-  }, [reload]);
+    const unsub = firebase
+      .firestore()
+      .collection('courseFetchConfigs')
+      .orderBy('createdAt', 'desc')
+      .limit(200)
+      .onSnapshot(
+        (snap) => {
+          const list: CourseFetchConfig[] = snap.docs.map(
+            (d) => ({ id: d.id, ...d.data() } as CourseFetchConfig)
+          );
+          setConfigs(list);
+          setLoading(false);
+          setLoadError(null);
+        },
+        (err) => {
+          console.error('courseFetchConfigs listener error:', err);
+          setLoadError(err.message);
+          setLoading(false);
+        }
+      );
+    return () => unsub();
+  }, []);
+
+  // For each config with an un-toasted runId, attach a run-doc listener that
+  // streams `phase` while running and fires a terminal toast exactly once.
+  // Historical terminal runs (configs loaded at mount where lastStatus is
+  // not 'running') are added to toastedRunIdsRef so we never retroactively
+  // toast them.
+  React.useEffect(() => {
+    for (const c of configs) {
+      const runId = c.lastRunId;
+      if (!runId) continue;
+      if (c.lastStatus !== 'running') {
+        toastedRunIdsRef.current.add(runId);
+        continue;
+      }
+      if (toastedRunIdsRef.current.has(runId)) continue;
+      if (runSubsRef.current.has(runId)) continue;
+
+      const configId = c.id;
+      const label = c.label;
+      const ref = firebase
+        .firestore()
+        .collection('courseFetchConfigs')
+        .doc(configId)
+        .collection('runs')
+        .doc(runId);
+      const unsub = ref.onSnapshot(
+        (snap) => {
+          if (!snap.exists) return;
+          const data = snap.data() as Record<string, unknown>;
+          const status = String(data.status ?? '');
+          if (status === 'running') {
+            setActiveRuns((prev) => ({
+              ...prev,
+              [configId]: {
+                runId,
+                phase:
+                  (data.phase as CourseFetchPhase | undefined) ?? 'fetching',
+                cancelling:
+                  prev[configId]?.cancelling || data.cancelRequested === true,
+                triggeredBy:
+                  (data.triggeredBy as 'manual' | 'scheduled' | undefined) ??
+                  'manual',
+              },
+            }));
+            return;
+          }
+          // Terminal transition — remove active run, toast once, self-destroy.
+          setActiveRuns((prev) => {
+            const existing = prev[configId];
+            if (!existing || existing.runId !== runId) return prev;
+            const { [configId]: _drop, ...rest } = prev;
+            return rest;
+          });
+          if (!toastedRunIdsRef.current.has(runId)) {
+            toastedRunIdsRef.current.add(runId);
+            const courseCount = Number(data.courseCount ?? 0);
+            const sectionCount = Number(data.sectionCount ?? 0);
+            const errors = Array.isArray(data.errors)
+              ? (data.errors as unknown[]).filter(
+                  (e): e is string => typeof e === 'string'
+                )
+              : [];
+            if (status === 'success') {
+              toast.success(
+                `${label}: ${courseCount} course${
+                  courseCount === 1 ? '' : 's'
+                } · ${sectionCount} section${sectionCount === 1 ? '' : 's'}`
+              );
+            } else if (status === 'partial_success') {
+              toast(
+                `${label}: partial — ${courseCount} courses, ${
+                  errors.length
+                } error${errors.length === 1 ? '' : 's'}`,
+                { icon: '⚠️' }
+              );
+            } else if (status === 'cancelled') {
+              toast(
+                `${label}: cancelled — ${courseCount} course${
+                  courseCount === 1 ? '' : 's'
+                } written`,
+                { icon: '⏹️' }
+              );
+            } else {
+              toast.error(`${label}: ${errors[0] ?? 'Run failed'}`);
+            }
+          }
+          const u = runSubsRef.current.get(runId);
+          if (u) {
+            u();
+            runSubsRef.current.delete(runId);
+          }
+        },
+        (err) => {
+          console.error(`run ${runId} listener error:`, err);
+        }
+      );
+      runSubsRef.current.set(runId, unsub);
+    }
+  }, [configs]);
+
+  // Unmount cleanup for any still-open run-doc subscriptions.
+  React.useEffect(() => {
+    const subs = runSubsRef.current;
+    return () => {
+      subs.forEach((unsub) => unsub());
+      subs.clear();
+    };
+  }, []);
 
   const handleCreate = () => {
     setEditing(null);
@@ -445,33 +626,54 @@ export default function AutoFetchPanel({
       toast.error(e instanceof Error ? e.message : 'Update failed');
     }
   };
-  const handleTrigger = async (
-    c: CourseFetchConfig,
-    includeCourses?: string[]
-  ) => {
-    setRunningId(c.id);
-    const toastId = toast.loading(`Running ${c.label}…`);
-    try {
-      const res = await api.trigger(c.id, includeCourses);
-      toast.dismiss(toastId);
-      if (res.status === 'success') {
-        toast.success(
-          `Done: ${res.courseCount} courses · ${res.sectionCount} sections`
-        );
-      } else if (res.status === 'partial_success') {
-        toast(
-          `Partial: ${res.courseCount} courses, ${res.errors.length} errors`,
-          { icon: '⚠️' }
-        );
-      } else {
-        toast.error(res.errors[0] ?? 'Run failed');
-      }
-      reload();
-    } catch (e) {
-      toast.dismiss(toastId);
+  // Fires the trigger and returns. Terminal state + toasts flow through the
+  // run-doc snapshot listener above, not this promise — the Cloud Function
+  // call blocks until the run completes, but we don't need that for the UI
+  // since the snapshot already reflects 'running' immediately.
+  const startRun = (c: CourseFetchConfig, includeCourses?: string[]) => {
+    // Optimistic placeholder so the card shows "Fetching…" + disabled Cancel
+    // until the snapshot fills in the real runId.
+    setActiveRuns((prev) =>
+      prev[c.id]
+        ? prev
+        : {
+            ...prev,
+            [c.id]: {
+              runId: '',
+              phase: 'fetching',
+              cancelling: false,
+              triggeredBy: 'manual',
+            },
+          }
+    );
+    api.trigger(c.id, includeCourses).catch((e) => {
       toast.error(e instanceof Error ? e.message : 'Run failed');
-    } finally {
-      setRunningId(null);
+      setActiveRuns((prev) => {
+        const existing = prev[c.id];
+        if (!existing || existing.runId !== '') return prev;
+        const { [c.id]: _drop, ...rest } = prev;
+        return rest;
+      });
+    });
+  };
+
+  const handleCancel = async (c: CourseFetchConfig) => {
+    const active = activeRuns[c.id];
+    if (!active || !active.runId) return;
+    setActiveRuns((prev) =>
+      prev[c.id]
+        ? { ...prev, [c.id]: { ...prev[c.id], cancelling: true } }
+        : prev
+    );
+    try {
+      await api.cancelRun(c.id, active.runId);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Cancel failed');
+      setActiveRuns((prev) =>
+        prev[c.id]
+          ? { ...prev, [c.id]: { ...prev[c.id], cancelling: false } }
+          : prev
+      );
     }
   };
   const runPreview = React.useCallback(
@@ -500,10 +702,11 @@ export default function AutoFetchPanel({
     setPreviewData(null);
     setPreviewError(null);
   };
-  const handleApplyFromPreview = async (selectedCodes: string[]) => {
+  const handleApplyFromPreview = (selectedCodes: string[]) => {
     if (!previewConfig) return;
-    await handleTrigger(previewConfig, selectedCodes);
+    const cfg = previewConfig;
     handleClosePreview();
+    startRun(cfg, selectedCodes);
   };
 
   const handleSubmit = async (
@@ -557,8 +760,10 @@ export default function AutoFetchPanel({
             </Typography>
             <Typography variant="body2" color="text.secondary">
               Each workflow fetches from a provider, applies your filters, and
-              writes into the target semester&apos;s course list. Schedule a
-              cadence or run on-demand. Manual Excel uploads are preserved.
+              writes into the target semester&apos;s course list. Runs always
+              start from Preview, and a running job — whether manual or
+              scheduled — can be cancelled mid-flight. Manual Excel uploads are
+              preserved.
             </Typography>
           </Stack>
           <Stack direction="row" spacing={1}>
@@ -657,11 +862,11 @@ export default function AutoFetchPanel({
             key={c.id}
             config={c}
             currentSemester={currentSemester}
-            running={runningId === c.id}
+            activeRun={activeRuns[c.id] ?? null}
             previewing={previewLoading && previewConfig?.id === c.id}
             onToggle={(enabled) => handleToggle(c, enabled)}
-            onRun={() => handleTrigger(c)}
             onPreview={() => handlePreview(c)}
+            onCancel={() => handleCancel(c)}
             onEdit={() => handleEdit(c)}
             onDelete={() => handleDelete(c)}
             onHistory={() => setHistoryId(c.id)}
@@ -691,7 +896,7 @@ export default function AutoFetchPanel({
         preview={previewData}
         loading={previewLoading}
         loadError={previewError}
-        applying={runningId === previewConfig?.id}
+        applying={false}
         onClose={handleClosePreview}
         onRetry={() => previewConfig && runPreview(previewConfig)}
         onApply={handleApplyFromPreview}

--- a/src/app/help/content.ts
+++ b/src/app/help/content.ts
@@ -289,13 +289,13 @@ export const ADMIN_GUIDE: HelpGuide = {
       steps: [
         'Pick the target semester at the top, or create a new one. Use Hide/Unhide to control whether students can see it — keep it hidden while you stage data.',
         'Auto-fetch tab: click "New workflow" to build a pipeline — choose a source (e.g. one.uf.edu), filter by department / code prefix / course number range / level / campus, pick a refresh cadence (manual, hourly, daily, weekly, or every N hours), and point it at a semester. Toggle Enabled to arm the schedule.',
-        'Auto-fetch → Preview: always run Preview first on a new workflow. The dialog shows a new-vs-update diff so you know what will change before applying. "Run now" triggers it on demand; History shows past runs with counts and any errors.',
+        'Auto-fetch → Run…: every run starts from Preview (a dry fetch with a new-vs-update diff). Apply the subset you want, and the workflow card shows live phase (Fetching… / Writing…) with a Cancel run button — for manual runs and live scheduled runs alike. Cancelled runs keep any writes that committed before cancel fired. History shows past runs with counts and any errors.',
         'Upload & maintain tab: use "Upload Semester Data" to ingest an Excel course list manually (code, title, instructor emails, meeting times, enrollment cap). "Upload Employment Actions" attaches the UFID → action mapping for the term. Manual uploads are preserved across auto-fetch runs.',
         'Manage courses tab: browse the rows currently in the semester, edit typos, and remove stragglers. "Clear Semester Data" wipes every course for the selected semester — use only when you are about to reload from scratch.',
       ],
       tips: [
         'Your active department is stamped on every course you write — whether auto-fetched or uploaded. Super admins who belong to multiple departments should confirm the active department in their Profile before writing.',
-        'Preview before "Run now": the dry-run catches filter mistakes (wrong code prefix, stale term) without touching Firestore.',
+        'Preview is required: the dry-run catches filter mistakes (wrong code prefix, stale term) without touching Firestore. There is no "Run without preview" path.',
         'Partial-success status means some sections errored; open History on the workflow to see which ones.',
         'If the Auto-fetch tab says it cannot load workflows, the course-fetch Cloud Functions are not deployed — redeploy from functions/.',
         'Clearing is permanent. Back up the Excel source (or disable workflows) before running it.',
@@ -385,7 +385,7 @@ export const ADMIN_GUIDE: HelpGuide = {
     },
     {
       q: 'A fetch workflow is stuck in "running" — what do I do?',
-      a: 'Open History on the workflow to see the run record. If the provider timed out, disable the schedule, fix the config (filters too broad, wrong term), then Preview + Run now to retry.',
+      a: 'Open History on the workflow to see the run record. If the provider timed out, disable the schedule, fix the config (filters too broad, wrong term), then Preview and Apply to retry.',
     },
     {
       q: 'How do I add a new department to Course Connect?',

--- a/src/hooks/useCourseFetch.ts
+++ b/src/hooks/useCourseFetch.ts
@@ -81,10 +81,29 @@ export function useCourseFetchApi() {
     []
   );
 
+  const cancelRun = useCallback(
+    async (
+      configId: string,
+      runId: string
+    ): Promise<{ cancelled: boolean; alreadyTerminal?: boolean }> => {
+      return callFunction('cancelCourseFetchRun', { configId, runId });
+    },
+    []
+  );
+
   // Memoize the returned object so callers can depend on its identity
   // (e.g. inside useEffect deps) without triggering re-render loops.
   return useMemo(
-    () => ({ list, create, update, remove, trigger, preview, listRuns }),
-    [list, create, update, remove, trigger, preview, listRuns]
+    () => ({
+      list,
+      create,
+      update,
+      remove,
+      trigger,
+      preview,
+      listRuns,
+      cancelRun,
+    }),
+    [list, create, update, remove, trigger, preview, listRuns, cancelRun]
   );
 }

--- a/src/types/courseFetch.ts
+++ b/src/types/courseFetch.ts
@@ -25,7 +25,10 @@ export type CourseFetchStatus =
   | 'running'
   | 'success'
   | 'partial_success'
-  | 'failed';
+  | 'failed'
+  | 'cancelled';
+
+export type CourseFetchPhase = 'fetching' | 'writing';
 
 // Admin-editable config. Source of truth is `courseFetchConfigs/{id}`.
 export interface CourseFetchConfig {
@@ -84,6 +87,10 @@ export interface CourseFetchRun {
   durationMs?: number;
   triggeredBy: 'manual' | 'scheduled';
   triggeredByUid?: string;
+  phase?: CourseFetchPhase;
+  cancelRequested?: boolean;
+  cancelRequestedBy?: string;
+  cancelRequestedAt?: FirestoreLikeTimestamp;
 }
 
 // Normalized course in the app-facing catalog.


### PR DESCRIPTION
Runs can no longer bypass Preview, and in-flight runs (manual or scheduled) are cancellable mid-flight from the workflow card. Cooperative cancellation uses a `cancelRequested` flag on the run doc that the pipeline polls between provider pages and between batch commits, so any writes that land before cancel fires are preserved.

Server:
- new cancelCourseFetchRun HTTPS function (admin-only, idempotent)
- checkCancel threaded through fetchCoursesForConfig, UF provider worker loops, and commitCoursesAndSections (between batches)
- runner writes phase ('fetching' -> 'writing') and a 'cancelled' terminal state with partial counts; lastError cleared on cancel, nextRefreshAt still advances so cron doesn't retry-storm

Client:
- AutoFetchPanel replaces polling with live onSnapshot on configs and the active run doc; drops the 'Run now' bypass, makes Preview the sole entry point, and shows phase chip + Cancel run button on the card
- cancel fires immediately (no confirm); scheduled runs are equally cancellable and get a 'scheduled' chip while active
- terminal toasts fire once per runId with a historical-runs guard