### PR TITLE
ui(courses): show instructor instead of section number in labels

### DIFF
--- a/src/app/applications/[semester]/ApplicationsModal.tsx
+++ b/src/app/applications/[semester]/ApplicationsModal.tsx
@@ -15,6 +15,7 @@ import { prettyCourseId } from '@/hooks/useSemesterOptions';
 export interface ApplicationModalProps {
   courseId: string;
   semester?: string;
+  instructor?: unknown;
   open: boolean;
   onClose: () => void;
   id: string;
@@ -26,6 +27,7 @@ export interface ApplicationModalProps {
 export function ApplicationModal({
   courseId,
   semester,
+  instructor,
   open,
   onClose,
   id,
@@ -58,7 +60,9 @@ export function ApplicationModal({
     >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 border-b">
-        <div className="text-sm font-medium">{prettyCourseId(courseId)}</div>
+        <div className="text-sm font-medium">
+          {prettyCourseId(courseId, instructor)}
+        </div>
         <div className="flex items-center gap-2">
           <a
             className="text-xs underline"
@@ -90,6 +94,7 @@ export function ApplicationModal({
               data={documentData}
               courseId={courseId}
               semester={semester}
+              instructor={instructor}
               documentId={id}
               status={documentStatus}
             />

--- a/src/app/applications/[semester]/[className]/page.tsx
+++ b/src/app/applications/[semester]/[className]/page.tsx
@@ -17,6 +17,7 @@ import { CourseApplicationsTable } from '@/components/ApplicationsTable/Applicat
 import { ApplicationModal } from '../ApplicationsModal';
 import { useFetchApplicationById } from '@/hooks/Applications/useFetchApplicationById';
 import { SemesterName, prettyCourseId } from '@/hooks/useSemesterOptions';
+import { useCourseDetails } from '@/hooks/Courses/useFetchCourse';
 import { addSemesterToCourseDoc } from '@/hooks/Applications/ApplicationFunctions';
 import { resolveCourseStatus } from '@/firebase/applications/applicationRepository';
 
@@ -43,6 +44,9 @@ const ApplicationsPage: FC = () => {
     semesterId,
     statuses
   );
+
+  const { course } = useCourseDetails(courseId, semesterId as SemesterName);
+  const instructor = course?.instructor;
 
   const rows = data?.all ?? [];
 
@@ -94,7 +98,7 @@ const ApplicationsPage: FC = () => {
 
   return (
     <PageLayout
-      mainTitle={`${prettyCourseId(courseId)} - ${semesterId}`}
+      mainTitle={`${prettyCourseId(courseId, instructor)} - ${semesterId}`}
       navItems={getNavItems(role)}
     >
       <div className="mb-6">
@@ -109,6 +113,7 @@ const ApplicationsPage: FC = () => {
         semester={semesterId as SemesterName}
         selectedFilter={statusFilter}
         courseId={courseId}
+        instructor={instructor}
         loading={isLoading}
       />
       {modal && id && (
@@ -116,6 +121,7 @@ const ApplicationsPage: FC = () => {
           open={Boolean(modal && id)}
           courseId={courseId}
           semester={semesterId}
+          instructor={instructor}
           id={id ?? ''}
           onClose={close}
           parentPath={pathname}

--- a/src/components/ApplicationPreview/ApplicationPreview.tsx
+++ b/src/components/ApplicationPreview/ApplicationPreview.tsx
@@ -14,6 +14,7 @@ type Props = {
   documentId: string;
   courseId: string;
   semester?: string;
+  instructor?: unknown;
 };
 
 export function ApplicationPreview({
@@ -22,6 +23,7 @@ export function ApplicationPreview({
   courseId,
   status,
   semester,
+  instructor,
 }: Props) {
   const {
     firstname,
@@ -253,7 +255,8 @@ export function ApplicationPreview({
         description={
           confirm.kind === 'approve'
             ? `This will mark the application as approved for ${prettyCourseId(
-                courseId
+                courseId,
+                instructor
               )}.`
             : `This will mark the application as denied and notify the applicant.`
         }

--- a/src/components/ApplicationsTable/ApplicationsTable.tsx
+++ b/src/components/ApplicationsTable/ApplicationsTable.tsx
@@ -165,6 +165,7 @@ export interface CourseApplicationsTableProps {
   emptyMessage?: string;
   courseId: string;
   semester: SemesterName;
+  instructor?: unknown;
 }
 
 export const CourseApplicationsTable: React.FC<
@@ -178,6 +179,7 @@ export const CourseApplicationsTable: React.FC<
   loading = false,
   emptyMessage = 'No applications for this course.',
   courseId,
+  instructor,
 }) => {
   const [confirm, setConfirm] = React.useState<{
     open: boolean;
@@ -417,7 +419,8 @@ export const CourseApplicationsTable: React.FC<
         description={
           confirm.kind === 'approve'
             ? `This will mark the application as approved for ${prettyCourseId(
-                courseId
+                courseId,
+                instructor
               )}.`
             : `This will mark the application as denied and notify the applicant.`
         }

--- a/src/components/StatusTable/StatusTable.tsx
+++ b/src/components/StatusTable/StatusTable.tsx
@@ -1,5 +1,8 @@
 // StatusTable.tsx – updated to use design-system colours from tailwind.config.js
 import React from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { doc, getDoc } from 'firebase/firestore';
+import firebase from '@/firebase/firebase_config';
 import { prettyCourseId } from '@/hooks/useSemesterOptions';
 
 /* Pill that reflects the four possible states */
@@ -91,6 +94,22 @@ function flattenCourses(
   return out;
 }
 
+async function fetchCourseInstructor(
+  semester: string,
+  courseId: string
+): Promise<unknown> {
+  if (!semester || !courseId) return undefined;
+  const ref = doc(
+    firebase.firestore(),
+    'semesters',
+    semester,
+    'courses',
+    courseId
+  );
+  const snap = await getDoc(ref);
+  return snap.exists() ? snap.data()?.professor_names : undefined;
+}
+
 export const StatusTable: React.FC<StatusTableProps> = ({
   assignments,
   courses,
@@ -99,6 +118,22 @@ export const StatusTable: React.FC<StatusTableProps> = ({
   position,
   dateApplied,
 }) => {
+  const flattened = React.useMemo(
+    () => (courses ? flattenCourses(courses) : []),
+    [courses]
+  );
+
+  const instructorQueries = useQueries({
+    queries: flattened.map(({ courseId, semester }) => ({
+      queryKey: ['courseInstructor', semester, courseId],
+      queryFn: () => fetchCourseInstructor(semester, courseId),
+      enabled: Boolean(semester && courseId),
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
   const rows: Row[] = [];
 
   /* accepted assignments */
@@ -112,22 +147,20 @@ export const StatusTable: React.FC<StatusTableProps> = ({
   );
 
   /* per-course statuses */
-  if (courses) {
-    flattenCourses(courses).forEach(({ courseId, semester, state }) => {
-      let status: Row['status'] = 'pending';
-      if (state === 'approved' && adminApproved) status = 'accepted';
-      else if (state === 'denied') status = 'rejected';
-      else if (state === 'applied') status = 'in-progress';
-      const pretty = prettyCourseId(courseId);
-      const label = semester ? `${pretty} (${semester})` : pretty;
-      rows.push({
-        application: label,
-        position: position,
-        submitted: dateApplied,
-        status,
-      });
+  flattened.forEach(({ courseId, semester, state }, i) => {
+    let status: Row['status'] = 'pending';
+    if (state === 'approved' && adminApproved) status = 'accepted';
+    else if (state === 'denied') status = 'rejected';
+    else if (state === 'applied') status = 'in-progress';
+    const pretty = prettyCourseId(courseId, instructorQueries[i]?.data);
+    const label = semester ? `${pretty} (${semester})` : pretty;
+    rows.push({
+      application: label,
+      position: position,
+      submitted: dateApplied,
+      status,
     });
-  }
+  });
 
   /* whole application denied */
   if (adminDenied) rows.forEach((r) => (r.status = 'rejected'));

--- a/src/hooks/useSemesterOptions.ts
+++ b/src/hooks/useSemesterOptions.ts
@@ -122,21 +122,42 @@ function prettyCode(code: string, fallback?: string): string {
   return m ? `${m[1]} ${m[2]}` : code;
 }
 
+// Normalize a `professor_names` field for display. Firestore stores either a
+// string ("Rambo, Keith Jeffrey") or an array of strings; collapse arrays to a
+// comma-separated list and strip placeholder values.
+export function formatInstructor(raw: unknown): string {
+  const list = Array.isArray(raw) ? raw : [raw];
+  const cleaned = list
+    .map((v) => String(v ?? '').trim())
+    .filter(
+      (v) =>
+        v &&
+        v.toLowerCase() !== 'undefined' &&
+        v.toLowerCase() !== 'undef' &&
+        v.toLowerCase() !== 'unknown'
+    );
+  return cleaned.join(', ');
+}
+
 // Render a `semesters/*/courses/*` doc id for display. New canonical ids look
-// like `EEL3111C__10747` (code__classNumber) — show as `EEL 3111C · #10747`.
-// Legacy `EEL3111C : Rambo,Keith Jeffrey` ids are already human-readable, so
-// pass them through as-is.
-export function prettyCourseId(rawId: string): string {
+// like `EEL3111C__10747` (code__classNumber). When an instructor is supplied,
+// prefer "EEL 3111C · Rambo, Keith Jeffrey"; otherwise fall back to the class
+// number (`EEL 3111C · #10747`). Legacy `EEL3111C : Rambo,Keith Jeffrey` ids
+// are already human-readable, so pass them through as-is.
+export function prettyCourseId(rawId: string, instructor?: unknown): string {
   if (!rawId) return '';
+  const instr = formatInstructor(instructor);
   const dunderIdx = rawId.indexOf('__');
   if (dunderIdx !== -1) {
     const code = rawId.slice(0, dunderIdx).trim().toUpperCase();
     const classNumber = rawId.slice(dunderIdx + 2).trim();
     const display = prettyCode(code);
+    if (instr) return `${display} · ${instr}`;
     return classNumber ? `${display} · #${classNumber}` : display;
   }
   if (rawId.includes(' : ')) return rawId;
-  return prettyCode(rawId.trim().toUpperCase());
+  const display = prettyCode(rawId.trim().toUpperCase());
+  return instr ? `${display} · ${instr}` : display;
 }
 
 export function parseCoursesMinimal(


### PR DESCRIPTION
`prettyCourseId` now takes an optional instructor and renders "EEL 3111C · Rambo, Keith Jeffrey" when one is supplied, falling back to the class number "#10747" otherwise. Per-course pages fetch the instructor via useCourseDetails and pass it through the modal, preview, and approve dialog; StatusTable resolves instructors per row with batched useQueries lookups.