### PR TITLE
refactor(courses): key semester course docs by (course, instructor)

### DIFF
--- a/docs/course-fetch-pipeline.md
+++ b/docs/course-fetch-pipeline.md
@@ -23,15 +23,19 @@ UI edits configs.
 
 Each run writes to two places:
 
-1. **Live semester** — one doc per section at
-   `semesters/{SemesterName}/courses/{code}__{classNumber}`, matching the
-   existing Excel-upload schema (`class_number`, `professor_emails`,
-   `professor_usernames`, `professor_names`, `code`, `credits`,
-   `department`, `enrollment_cap`, `enrolled`, `title`, `semester`,
-   `meeting_times[{day, time, location}]`) plus `source: 'auto-fetch'` +
-   `sourceConfigId`. `SemesterName` comes from the config's term+year,
-   capitalized (e.g. Fall 2026). Using `__` in the doc id guarantees no
-   collision with Excel rows keyed by `{code} : {instructor}`.
+1. **Live semester** — one doc per (course, professor) at
+   `semesters/{SemesterName}/courses/{code} : {instructor}`, matching the
+   Excel-upload schema (`class_number`, `class_numbers`,
+   `professor_emails`, `professor_usernames`, `professor_names`, `code`,
+   `credits`, `department`, `enrollment_cap`, `enrolled`, `title`,
+   `semester`, `meeting_times[{day, time, location}]`, `section_count`)
+   plus `source: 'auto-fetch'` + `sourceConfigId`. `SemesterName` comes
+   from the config's term+year, capitalized (e.g. Fall 2026). Multiple
+   sections of the same course taught by the same prof get merged into a
+   single doc — `class_numbers` lists each section's class number,
+   `enrollment_cap` and `enrolled` are summed, and `meeting_times`
+   concatenates the per-section entries. Excel uploads write into the
+   same docs (same key), so the two paths converge.
 
    `professor_usernames` is the lowercased local part of each entry in
    `professor_emails` (e.g. `john.doe@ece.ufl.edu` →
@@ -94,11 +98,13 @@ department, code)` for catalog queries, and a collection-group index on
 ## Preview (dry run)
 
 `previewCourseFetch` runs the full fetch → filter → normalize pipeline
-without writing anything, then diffs `{code}__{classNumber}` doc ids
-against the target `semesters/{SemesterName}/courses/*` collection.
-Every previewed section is tagged `new` (not in the semester yet) or
-`updated` (exists — Apply will merge in-place). Response is capped at
-1000 courses; rare unfiltered previews set `truncated: true` while Apply
+without writing anything, then groups sections by (course, instructor)
+and diffs each `{code} : {instructor}` doc id against the target
+`semesters/{SemesterName}/courses/*` collection. Every previewed row is
+tagged `new` (not in the semester yet) or `updated` (exists — Apply will
+merge in-place). Multi-section rows show the merged class numbers and
+summed enrollment that Apply will write. Response is capped at 1000
+courses; rare unfiltered previews set `truncated: true` while Apply
 still writes all matching courses.
 
 ## How scheduled refresh works

--- a/functions/src/courseFetch.ts
+++ b/functions/src/courseFetch.ts
@@ -266,7 +266,10 @@ export const triggerCourseFetch = functions.https.onRequest(
 // the UI can tag rows as "new" or "updated".
 
 type PreviewSectionRow = {
+  // After grouping by (course, instructor) one preview row may represent
+  // multiple sections taught by the same prof — class numbers are joined.
   classNumber: string;
+  classNumbers: string[];
   sectionNumber?: string;
   instructors: Array<{ name: string; email?: string }>;
   meetingTimes: Array<{
@@ -282,6 +285,7 @@ type PreviewSectionRow = {
   enrolled?: number;
   campus?: string;
   deliveryMode?: string;
+  sectionCount: number;
   diffStatus: 'new' | 'updated';
 };
 
@@ -301,6 +305,32 @@ function semesterNameFrom(
 ): string {
   const cap = term.charAt(0).toUpperCase() + term.slice(1);
   return `${cap} ${year}`;
+}
+
+// Mirror of `instructorKeyFromSection` in `courseFetcher/runner.ts`. Kept
+// inline here so the preview's diff key matches the runner's write key
+// without having to plumb the helper through the pipeline boundary.
+function previewInstructorKey(
+  instructors: Array<{ name: string; email?: string }>
+): string {
+  const joined = instructors
+    .map((i) => (i.name ?? '').trim())
+    .filter(Boolean)
+    .join(', ');
+  const cleaned = joined.replace(/\s+/g, ' ').trim();
+  return cleaned || 'TBA';
+}
+
+function sumNumbers(values: Array<number | undefined>): number | undefined {
+  let total = 0;
+  let any = false;
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) {
+      total += v;
+      any = true;
+    }
+  }
+  return any ? total : undefined;
 }
 
 // Fetch just the doc ids already present in the target semester so we can
@@ -352,31 +382,54 @@ export const previewCourseFetch = functions
         existingSemesterDocIds(targetSemester),
       ]);
 
-      // Group sections under their course and compute diff status.
+      // Group sections by (course, instructor). One preview row per group
+      // (the doc auto-fetch will write), then diff each row's doc id against
+      // the target semester. Mirrors the runner's `${code} : ${instructor}`
+      // doc-id format and section-merging behavior so the preview accurately
+      // reflects what Apply will write.
+      const grouped = new Map<string, Map<string, typeof result.sections>>();
+      for (const s of result.sections) {
+        const courseKey = s.courseCode;
+        const instructorKey = previewInstructorKey(s.instructors);
+        let byInstructor = grouped.get(courseKey);
+        if (!byInstructor) {
+          byInstructor = new Map();
+          grouped.set(courseKey, byInstructor);
+        }
+        const bucket = byInstructor.get(instructorKey);
+        if (bucket) bucket.push(s);
+        else byInstructor.set(instructorKey, [s]);
+      }
+
       const sectionsByCourse = new Map<string, PreviewSectionRow[]>();
       let newCount = 0;
       let updatedCount = 0;
-      for (const s of result.sections) {
-        const docId = `${s.courseCode}__${s.classNumber}`;
-        const diffStatus: 'new' | 'updated' = existing.has(docId)
-          ? 'updated'
-          : 'new';
-        if (diffStatus === 'new') newCount++;
-        else updatedCount++;
-        const row: PreviewSectionRow = {
-          classNumber: s.classNumber,
-          sectionNumber: s.sectionNumber,
-          instructors: s.instructors,
-          meetingTimes: s.meetingTimes,
-          enrollmentCap: s.enrollmentCap,
-          enrolled: s.enrolled,
-          campus: s.campus,
-          deliveryMode: s.deliveryMode,
-          diffStatus,
-        };
-        const bucket = sectionsByCourse.get(s.courseCode);
-        if (bucket) bucket.push(row);
-        else sectionsByCourse.set(s.courseCode, [row]);
+      for (const [courseCode, byInstructor] of grouped) {
+        const rows: PreviewSectionRow[] = [];
+        for (const [instructorKey, sections] of byInstructor) {
+          const docId = `${courseCode} : ${instructorKey.replace(/\//g, '-')}`;
+          const diffStatus: 'new' | 'updated' = existing.has(docId)
+            ? 'updated'
+            : 'new';
+          if (diffStatus === 'new') newCount++;
+          else updatedCount++;
+          const head = sections[0];
+          const classNumbers = sections.map((s) => s.classNumber);
+          rows.push({
+            classNumber: classNumbers.join(', '),
+            classNumbers,
+            sectionNumber: head.sectionNumber,
+            instructors: head.instructors,
+            meetingTimes: sections.flatMap((s) => s.meetingTimes),
+            enrollmentCap: sumNumbers(sections.map((s) => s.enrollmentCap)),
+            enrolled: sumNumbers(sections.map((s) => s.enrolled)),
+            campus: head.campus,
+            deliveryMode: head.deliveryMode,
+            sectionCount: sections.length,
+            diffStatus,
+          });
+        }
+        sectionsByCourse.set(courseCode, rows);
       }
 
       const courses: PreviewCourseRow[] = result.courses

--- a/functions/src/courseFetcher/runner.ts
+++ b/functions/src/courseFetcher/runner.ts
@@ -57,26 +57,78 @@ function toLegacyMeetingTimes(times: NormalizedMeetingTime[]): Array<{
   }));
 }
 
+// Stable instructor key used for both the doc id and section grouping. We
+// normalize the joined name string so two sections of the same course taught
+// by the same prof land on the same doc — auto-fetch's normalize step keeps
+// names consistent within a single run, so a trim/whitespace-collapse is
+// enough. Falls back to 'TBA' when a section has no listed instructor.
+function instructorKeyFromSection(section: NormalizedSection): string {
+  const joined = section.instructors
+    .map((i) => (i.name ?? '').trim())
+    .filter(Boolean)
+    .join(', ');
+  const cleaned = joined.replace(/\s+/g, ' ').trim();
+  return cleaned || 'TBA';
+}
+
+// Doc id used by the live semester layout. Matches the Excel upload format
+// (`UploadPanel.tsx`) so re-runs and re-uploads merge into the same doc.
+function semesterCourseDocId(code: string, instructorKey: string): string {
+  // Firestore doc ids cannot contain '/'. Other punctuation in instructor
+  // names (commas, periods) is fine.
+  const safeInstructor = instructorKey.replace(/\//g, '-');
+  return `${code} : ${safeInstructor}`;
+}
+
+function sumNumericStrings(values: Array<string | undefined>): string {
+  let total = 0;
+  let any = false;
+  for (const v of values) {
+    if (v == null || v === '') continue;
+    const n = Number(v);
+    if (Number.isFinite(n)) {
+      total += n;
+      any = true;
+    }
+  }
+  return any ? String(total) : '';
+}
+
 // Build a doc matching the existing semester-course schema used by the
-// Excel upload flow. The `source` + `sourceConfigId` fields let the UI
-// distinguish auto-fetched rows from manually uploaded ones.
+// Excel upload flow. One doc per (course, instructor) — multiple sections
+// taught by the same prof get merged so the catalog isn't fragmented per
+// section. The `source` + `sourceConfigId` fields let the UI distinguish
+// auto-fetched rows from manually uploaded ones.
 function buildSemesterCourseDoc(
   course: NormalizedCourse,
-  section: NormalizedSection,
+  sections: NormalizedSection[],
   semesterName: string,
   configId: string,
   provider: string
 ): Record<string, unknown> {
-  const instructorNames = section.instructors
-    .map((i) => i.name)
-    .filter(Boolean);
-  const instructorEmails = section.instructors
+  // Use the first section as the source of truth for instructor identity —
+  // grouping guarantees they all share the same instructor key.
+  const head = sections[0];
+  const instructorNames = head.instructors.map((i) => i.name).filter(Boolean);
+  const instructorEmails = head.instructors
     .map((i) => i.email)
     .filter((e): e is string => Boolean(e));
 
+  const classNumbers = sections.map((s) => s.classNumber).filter(Boolean);
+  const sectionNumbers = sections
+    .map((s) => s.sectionNumber)
+    .filter((s): s is string => Boolean(s));
+  const meetingTimes = sections.flatMap((s) =>
+    toLegacyMeetingTimes(s.meetingTimes)
+  );
+
   return {
-    class_number: section.classNumber,
+    // Backward-compat single-string field for consumers reading
+    // `class_number`. New code should prefer `class_numbers` (array).
+    class_number: classNumbers.join(', '),
+    class_numbers: classNumbers,
     code: course.code,
+    codeWithSpace: course.codeWithSpace,
     title: course.title,
     credits: course.credits ?? '',
     department: (course.department ?? '').toUpperCase(),
@@ -84,12 +136,18 @@ function buildSemesterCourseDoc(
     professor_names: instructorNames.join(', '),
     professor_emails: instructorEmails,
     professor_usernames: emailsToUsernames(instructorEmails),
-    enrollment_cap:
-      section.enrollmentCap != null ? String(section.enrollmentCap) : '',
-    enrolled: section.enrolled != null ? String(section.enrolled) : '',
-    title_section: section.sectionNumber ?? '',
+    enrollment_cap: sumNumericStrings(
+      sections.map((s) =>
+        s.enrollmentCap != null ? String(s.enrollmentCap) : undefined
+      )
+    ),
+    enrolled: sumNumericStrings(
+      sections.map((s) => (s.enrolled != null ? String(s.enrolled) : undefined))
+    ),
+    title_section: sectionNumbers.join(', '),
+    section_count: sections.length,
     semester: semesterName,
-    meeting_times: toLegacyMeetingTimes(section.meetingTimes),
+    meeting_times: meetingTimes,
     source: 'auto-fetch',
     sourceConfigId: configId,
     sourceProvider: provider,
@@ -155,14 +213,26 @@ async function commitCoursesAndSections(
     ? result.sections.filter((s) => isIncluded(s.courseCode))
     : result.sections;
 
-  // Index sections by courseCode so we can emit one legacy semester-course
-  // doc per (course, section) pair below.
-  const sectionsByCourse = new Map<string, NormalizedSection[]>();
+  // Group sections by (courseCode, instructorKey) so we emit one merged
+  // semester-course doc per (course, professor) pair instead of one per
+  // section. Inner map keys on the instructor key so a 4-section course
+  // taught by 2 profs produces 2 docs (one per prof, with that prof's
+  // sections merged), not 4.
+  const sectionsByCourseInstructor = new Map<
+    string,
+    Map<string, NormalizedSection[]>
+  >();
   for (const section of sectionsToWrite) {
-    const key = section.courseCode;
-    const bucket = sectionsByCourse.get(key);
+    const courseKey = section.courseCode;
+    const instructorKey = instructorKeyFromSection(section);
+    let byInstructor = sectionsByCourseInstructor.get(courseKey);
+    if (!byInstructor) {
+      byInstructor = new Map();
+      sectionsByCourseInstructor.set(courseKey, byInstructor);
+    }
+    const bucket = byInstructor.get(instructorKey);
     if (bucket) bucket.push(section);
-    else sectionsByCourse.set(key, [section]);
+    else byInstructor.set(instructorKey, [section]);
   }
 
   const semesterName = semesterNameFromConfig(config.term, config.year);
@@ -219,16 +289,19 @@ async function commitCoursesAndSections(
       )
     );
 
-    // 2) Live semester-course docs — one per section, matching the existing
-    // schema the app already reads. Doc id uses `__` to avoid colliding
-    // with Excel rows which use `${code} : ${instructor}`.
-    const sections = sectionsByCourse.get(course.code) ?? [];
-    for (const section of sections) {
-      const semDocId = `${course.code}__${section.classNumber}`;
+    // 2) Live semester-course docs — one per (course, professor). Multiple
+    // sections taught by the same prof get merged into a single doc so the
+    // catalog isn't fragmented per section. Matches the Excel upload doc-id
+    // format (`${code} : ${instructor}`) so re-runs and re-uploads converge
+    // on the same row.
+    const byInstructor =
+      sectionsByCourseInstructor.get(course.code) ?? new Map();
+    for (const [instructorKey, sections] of byInstructor) {
+      const semDocId = semesterCourseDocId(course.code, instructorKey);
       const semRef = semesterCourses.doc(semDocId);
       const semPayload = buildSemesterCourseDoc(
         course,
-        section,
+        sections,
         semesterName,
         configId,
         provider

--- a/src/app/admincourses/ConfigForm.tsx
+++ b/src/app/admincourses/ConfigForm.tsx
@@ -125,8 +125,9 @@ export default function ConfigForm({
             {targetSemester}
           </Typography>
           {'. '}
-          Re-runs update in place using <code>{`{code}__{classNumber}`}</code>{' '}
-          doc ids so Excel uploads are never overwritten.
+          Re-runs update in place using <code>{`{code} : {instructor}`}</code>{' '}
+          doc ids — one row per professor + course, with sections taught by the
+          same prof merged together.
         </Alert>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <TextField

--- a/src/app/admincourses/UploadPanel.tsx
+++ b/src/app/admincourses/UploadPanel.tsx
@@ -31,11 +31,26 @@ function normalizeClassNumber(raw: unknown): string {
   return String(raw ?? '').trim();
 }
 
+// Stable instructor key used in the doc id. Mirrors
+// `instructorKeyFromSection` in `functions/src/courseFetcher/runner.ts`:
+// trim + collapse whitespace, fall back to 'TBA' when missing. Keeping the
+// two writers aligned means re-runs and re-uploads merge into the same doc.
+function instructorKey(raw: unknown): string {
+  const cleaned = String(raw ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return cleaned || 'TBA';
+}
+
 // Doc-id shape shared with auto-fetch (`runner.ts::commitCoursesAndSections`).
-// Keeping these aligned means the auto-fetch and Excel paths write into the
-// same doc so re-runs merge in place instead of producing duplicates.
-function semesterCourseDocId(code: string, classNumber: string): string {
-  return `${code}__${classNumber}`;
+// One doc per (course, professor); section-level rows for the same prof get
+// merged on the same doc so re-uploads (and the auto-fetch pipeline) don't
+// produce duplicates.
+function semesterCourseDocId(code: string, instructor: string): string {
+  // Firestore doc ids cannot contain '/'. Other punctuation (commas in
+  // "Smith, John", periods, etc.) is permitted.
+  const safeInstructor = instructor.replace(/\//g, '-');
+  return `${code} : ${safeInstructor}`;
 }
 
 export interface UploadPanelProps {
@@ -108,7 +123,23 @@ export default function UploadPanel({
         sheetData.forEach((row: any) => data.push(row));
       });
 
-      const seen = new Set<string>();
+      // Group rows by (code, instructor) so multiple sections of the same
+      // course taught by the same prof land on a single merged doc instead
+      // of overwriting each other. Matches the auto-fetch grouping.
+      type RowGroup = {
+        code: string;
+        instructor: string;
+        instructorEmails: string[];
+        classNumbers: string[];
+        meetingTimes: Array<{ day: string; time: string; location: string }>;
+        enrollmentCap: number;
+        enrolled: number;
+        anyEnrollmentCap: boolean;
+        anyEnrolled: boolean;
+        credits: unknown;
+        title: unknown;
+      };
+      const groups = new Map<string, RowGroup>();
       let skippedMissingId = 0;
       for (const row of data) {
         const mappedRow: Record<string, any> = {
@@ -131,18 +162,65 @@ export default function UploadPanel({
           skippedMissingId++;
           continue;
         }
-        const docId = semesterCourseDocId(code, classNumber);
-        if (seen.has(docId)) continue;
-        seen.add(docId);
+        const instructor = instructorKey(mappedRow['Instructor']);
+        const docId = semesterCourseDocId(code, instructor);
 
         const rawEmails = mappedRow['Instructor Emails'] ?? 'undef';
-        const emailArray =
+        const emailArray: string[] =
           rawEmails === 'undef'
             ? []
             : rawEmails.split(';').map((e: string) => e.trim());
 
-        const instructor = String(mappedRow['Instructor'] ?? '').trim();
+        const cap = Number(mappedRow['Enr Cap']);
+        const enr = Number(mappedRow['Enrolled']);
 
+        const group = groups.get(docId);
+        if (group) {
+          if (!group.classNumbers.includes(classNumber)) {
+            group.classNumbers.push(classNumber);
+          }
+          for (const e of emailArray) {
+            if (e && !group.instructorEmails.includes(e)) {
+              group.instructorEmails.push(e);
+            }
+          }
+          group.meetingTimes.push({
+            day: mappedRow['Day/s']?.replaceAll(' ', '') ?? 'undef',
+            time: mappedRow['Time'] ?? 'undef',
+            location: mappedRow['Facility'] ?? 'undef',
+          });
+          if (Number.isFinite(cap)) {
+            group.enrollmentCap += cap;
+            group.anyEnrollmentCap = true;
+          }
+          if (Number.isFinite(enr)) {
+            group.enrolled += enr;
+            group.anyEnrolled = true;
+          }
+        } else {
+          groups.set(docId, {
+            code,
+            instructor,
+            instructorEmails: emailArray.filter(Boolean),
+            classNumbers: [classNumber],
+            meetingTimes: [
+              {
+                day: mappedRow['Day/s']?.replaceAll(' ', '') ?? 'undef',
+                time: mappedRow['Time'] ?? 'undef',
+                location: mappedRow['Facility'] ?? 'undef',
+              },
+            ],
+            enrollmentCap: Number.isFinite(cap) ? cap : 0,
+            enrolled: Number.isFinite(enr) ? enr : 0,
+            anyEnrollmentCap: Number.isFinite(cap),
+            anyEnrolled: Number.isFinite(enr),
+            credits: mappedRow['Min - Max Cred'],
+            title: mappedRow['Course Title'],
+          });
+        }
+      }
+
+      for (const [docId, g] of groups) {
         await firebase
           .firestore()
           .collection('semesters')
@@ -151,25 +229,23 @@ export default function UploadPanel({
           .doc(docId)
           .set(
             {
-              class_number: classNumber,
-              professor_emails: emailArray,
-              professor_usernames: emailsToUsernames(emailArray),
-              professor_names: instructor || 'undef',
-              code,
-              codeWithSpace: addCodeSpace(code),
-              credits: mappedRow['Min - Max Cred'] ?? 'undef',
+              class_number: g.classNumbers.join(', '),
+              class_numbers: g.classNumbers,
+              professor_emails: g.instructorEmails,
+              professor_usernames: emailsToUsernames(g.instructorEmails),
+              professor_names: g.instructor,
+              code: g.code,
+              codeWithSpace: addCodeSpace(g.code),
+              credits: g.credits ?? 'undef',
               department: uploadDeptCode,
-              enrollment_cap: mappedRow['Enr Cap'] ?? 'undef',
-              enrolled: mappedRow['Enrolled'] ?? 'undef',
-              title: mappedRow['Course Title'] ?? 'undef',
+              enrollment_cap: g.anyEnrollmentCap
+                ? String(g.enrollmentCap)
+                : 'undef',
+              enrolled: g.anyEnrolled ? String(g.enrolled) : 'undef',
+              title: g.title ?? 'undef',
+              section_count: g.classNumbers.length,
               semester,
-              meeting_times: [
-                {
-                  day: mappedRow['Day/s']?.replaceAll(' ', '') ?? 'undef',
-                  time: mappedRow['Time'] ?? 'undef',
-                  location: mappedRow['Facility'] ?? 'undef',
-                },
-              ],
+              meeting_times: g.meetingTimes,
               source: 'excel-upload',
             },
             { merge: true }
@@ -289,7 +365,7 @@ export default function UploadPanel({
     <Stack spacing={2}>
       <UploadCard
         title="Upload semester course data"
-        description="Import an .xlsx/.xls roster to this semester. Rows are keyed by code + instructor and won't collide with auto-fetch entries."
+        description="Import an .xlsx/.xls roster to this semester. Rows are keyed by code + instructor — multiple sections taught by the same prof are merged into one course row."
         action={
           <Button
             component="label"

--- a/src/app/applications/courseAssistant/page.tsx
+++ b/src/app/applications/courseAssistant/page.tsx
@@ -120,18 +120,20 @@ export default function Application() {
               const code = String(d.code ?? '')
                 .trim()
                 .toUpperCase();
+              const instructor = String(
+                d.professor_names ?? d.instructor ?? ''
+              ).trim();
               const classNumber = String(
                 d.class_number ?? d.classNumber ?? ''
               ).trim();
-              // Skip docs missing the canonical fields — the migration script
-              // backfills older Excel rows that predate this schema.
-              if (!code || !classNumber) return;
+              // Doc id is `${code} : ${instructor}`; instructor is the
+              // identifying field. Skip rows missing both code and an
+              // instructor — those can't be picker options.
+              if (!code || !instructor) return;
               allCourses.push({
                 code,
                 classNumber,
-                instructor: String(
-                  d.professor_names ?? d.instructor ?? ''
-                ).trim(),
+                instructor,
                 codeWithSpace: d.codeWithSpace,
                 semester: semesterId,
               });
@@ -156,8 +158,10 @@ export default function Application() {
       try {
         const courseNamesWithSemester = selectedCourses.map((course) => {
           const [semester, raw] = course.split('|||');
-          // New encoding: raw = `${code}__${classNumber}`. Peel off the code.
-          const code = raw.split('__')[0] ?? raw;
+          // Doc id is `${code} : ${instructor}` — peel off the code.
+          // Fall back to legacy `${code}__${classNumber}` for any picker
+          // entries built before the (code, instructor) unification.
+          const code = raw.split(' : ')[0] ?? raw.split('__')[0] ?? raw;
           return `${code.trim()} (${semester})`;
         });
 

--- a/src/hooks/useSemesterOptions.ts
+++ b/src/hooks/useSemesterOptions.ts
@@ -103,9 +103,11 @@ export type CourseOption = {
 };
 
 // Input for the course picker. Fields come straight from the semester's course
-// doc (`semesters/{sem}/courses/{id}`) — previously we reconstructed them by
-// splitting the doc id on ":" but the doc id is now `${code}__{classNumber}`
-// (shared with auto-fetch), so structured fields are authoritative.
+// doc (`semesters/{sem}/courses/{id}`). Doc id is `${code} : ${instructor}`
+// (shared between auto-fetch and Excel upload — see
+// `functions/src/courseFetcher/runner.ts::semesterCourseDocId`). `classNumber`
+// is informational only now (a comma-joined list when a prof teaches multiple
+// sections of the same course).
 export type CourseMinimalInput = {
   code: string;
   classNumber: string;
@@ -139,14 +141,23 @@ export function formatInstructor(raw: unknown): string {
   return cleaned.join(', ');
 }
 
-// Render a `semesters/*/courses/*` doc id for display. New canonical ids look
-// like `EEL3111C__10747` (code__classNumber). When an instructor is supplied,
-// prefer "EEL 3111C · Rambo, Keith Jeffrey"; otherwise fall back to the class
-// number (`EEL 3111C · #10747`). Legacy `EEL3111C : Rambo,Keith Jeffrey` ids
-// are already human-readable, so pass them through as-is.
+// Render a `semesters/*/courses/*` doc id for display. Canonical ids look
+// like `EEL3111C : Rambo, Keith Jeffrey` (code + instructor, both written
+// by the auto-fetch and Excel-upload paths). When an explicit instructor
+// is supplied it wins; otherwise we peel the instructor off the doc id.
+// Legacy `EEL3111C__10747` (code + classNumber) ids predating the (code,
+// instructor) unification are still rendered with a `#classNumber` tail.
 export function prettyCourseId(rawId: string, instructor?: unknown): string {
   if (!rawId) return '';
   const instr = formatInstructor(instructor);
+  const colonIdx = rawId.indexOf(' : ');
+  if (colonIdx !== -1) {
+    const code = rawId.slice(0, colonIdx).trim().toUpperCase();
+    const trailing = rawId.slice(colonIdx + 3).trim();
+    const display = prettyCode(code);
+    const finalInstr = instr || trailing;
+    return finalInstr ? `${display} · ${finalInstr}` : display;
+  }
   const dunderIdx = rawId.indexOf('__');
   if (dunderIdx !== -1) {
     const code = rawId.slice(0, dunderIdx).trim().toUpperCase();
@@ -155,7 +166,6 @@ export function prettyCourseId(rawId: string, instructor?: unknown): string {
     if (instr) return `${display} · ${instr}`;
     return classNumber ? `${display} · #${classNumber}` : display;
   }
-  if (rawId.includes(' : ')) return rawId;
   const display = prettyCode(rawId.trim().toUpperCase());
   return instr ? `${display} · ${instr}` : display;
 }
@@ -163,28 +173,31 @@ export function prettyCourseId(rawId: string, instructor?: unknown): string {
 export function parseCoursesMinimal(
   courses: CourseMinimalInput[]
 ): CourseOption[] {
-  return courses.map(
-    ({ code, classNumber, instructor, semester, codeWithSpace }) => {
-      const safeCode = String(code ?? '')
-        .trim()
-        .toUpperCase();
-      const display = prettyCode(safeCode, codeWithSpace);
-      const instrClean = String(instructor ?? '').trim();
-      const safeInstructor =
-        instrClean && instrClean.toLowerCase() !== 'undefined'
-          ? instrClean
-          : 'Instructor Unknown';
-      const department = safeCode.slice(0, 3).toUpperCase();
-      const docId = `${safeCode}__${String(classNumber ?? '').trim()}`;
+  return courses.map(({ code, instructor, semester, codeWithSpace }) => {
+    const safeCode = String(code ?? '')
+      .trim()
+      .toUpperCase();
+    const display = prettyCode(safeCode, codeWithSpace);
+    const instrClean = String(instructor ?? '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const safeInstructor =
+      instrClean && instrClean.toLowerCase() !== 'undefined'
+        ? instrClean
+        : 'Instructor Unknown';
+    const department = safeCode.slice(0, 3).toUpperCase();
+    // Mirror the doc-id format written by the auto-fetch runner and Excel
+    // uploader so picker selections round-trip back to the source doc.
+    const instructorForId = (instrClean || 'TBA').replace(/\//g, '-');
+    const docId = `${safeCode} : ${instructorForId}`;
 
-      return {
-        code: safeCode,
-        instructor: safeInstructor,
-        department,
-        semester,
-        value: `${semester}|||${docId}`,
-        name: `${display} : ${safeInstructor} (${semester})`,
-      };
-    }
-  );
+    return {
+      code: safeCode,
+      instructor: safeInstructor,
+      department,
+      semester,
+      value: `${semester}|||${docId}`,
+      name: `${display} : ${safeInstructor} (${semester})`,
+    };
+  });
 }


### PR DESCRIPTION
Auto-fetch and Excel upload now write one doc per (course, professor) at semesters/{Sem}/courses/{code} : {instructor} instead of one per section. Sections taught by the same prof get merged on the same doc: class_numbers becomes an array (class_number kept as a comma-joined string for back-compat), enrollment_cap and enrolled are summed, meeting_times concatenates, plus a section_count field. Preview groups and diffs the same way. Picker doc-id construction, the courseAssistant peel logic, and prettyCourseId all handle the new format with a legacy {code}__{classNumber} fallback for docs predating the change.