### PR TITLE
feat(assignments): make Requested Action a selectable dropdown

### DIFF
--- a/src/components/Dashboard/Applications/AssignView.tsx
+++ b/src/components/Dashboard/Applications/AssignView.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import firebase from '@/firebase/firebase_config';
 import 'firebase/firestore';
-import { Button, Grid, Input } from '@mui/material';
+import { Button, Grid, Input, MenuItem, Select } from '@mui/material';
 import Paper from '@mui/material/Paper';
 
 import { setDoc } from 'firebase/firestore';
@@ -29,6 +29,7 @@ export default function AppView({ uid }: AppViewProps) {
   const [biweeklyRate, setBiweeklyRate] = React.useState('');
   const [targetAmt, setTargetAmt] = React.useState('');
   const [remote, setRemote] = React.useState('');
+  const [requestedAction, setRequestedAction] = React.useState('NEW HIRE');
 
   // get application object from uid
   const applicationsRef = firebase.firestore().collection('assignments');
@@ -56,6 +57,7 @@ export default function AppView({ uid }: AppViewProps) {
       biweekly_rate: biweeklyRate,
       target_amount: targetAmt,
       remote: remote,
+      requested_action: requestedAction,
     });
   }
 
@@ -130,6 +132,8 @@ export default function AppView({ uid }: AppViewProps) {
           } else {
             setRemote(data.remote);
           }
+
+          setRequestedAction(data.requested_action ?? 'NEW HIRE');
           console.log(studentName);
         } else {
           console.log('No such document!');
@@ -373,8 +377,32 @@ export default function AppView({ uid }: AppViewProps) {
                           marginLeft="20px"
                           marginBottom="10px"
                           fontSize="15px"
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
                         >
-                          Requested Action: NEW HIRE
+                          Requested Action:{' '}
+                          <Select
+                            value={requestedAction}
+                            size="small"
+                            onChange={(e) =>
+                              setRequestedAction(e.target.value as string)
+                            }
+                            sx={{ fontSize: 13, minWidth: 120 }}
+                          >
+                            {[
+                              'NEW HIRE',
+                              'REAPPOINT',
+                              'TERMINATE',
+                              'LEAVE',
+                            ].map((opt) => (
+                              <MenuItem
+                                key={opt}
+                                value={opt}
+                                sx={{ fontSize: 13 }}
+                              >
+                                {opt}
+                              </MenuItem>
+                            ))}
+                          </Select>
                         </Typography>
 
                         <Typography

--- a/src/components/Dashboard/Applications/AssignmentGrid.tsx
+++ b/src/components/Dashboard/Applications/AssignmentGrid.tsx
@@ -7,6 +7,8 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
+  MenuItem,
+  Select,
   Tooltip,
 } from '@mui/material';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
@@ -64,6 +66,7 @@ interface Assignment {
   target_amount?: string;
   title?: string;
   remote?: string;
+  requested_action?: string;
 }
 
 interface AssignmentGridProps {
@@ -92,7 +95,7 @@ const DEFAULT_HIDDEN: VisibilityState = {
   proxyFirstName: false,
   proxyLastName: false,
   proxyEmail: false,
-  action: false,
+  action: true,
   pid: false,
   pname: false,
   start_date: false,
@@ -141,6 +144,7 @@ export default function AssignmentGrid({ userRole }: AssignmentGridProps) {
       'Biweekly Rate': a.biweekly_rate ?? '',
       'Target Amount': a.target_amount ?? '',
       'Supervisor UFID': a.supervisor_ufid ?? '',
+      'Requested Action': a.requested_action ?? 'NEW HIRE',
       Remote: a.remote ?? '',
       Timestamp: a.date ?? '',
       'Project ID': '000108927',
@@ -354,8 +358,47 @@ export default function AssignmentGrid({ userRole }: AssignmentGridProps) {
       {
         id: 'action',
         header: 'Requested Action',
-        accessorFn: () => 'NEW HIRE',
-        size: 140,
+        accessorFn: (r) => r.requested_action ?? 'NEW HIRE',
+        cell: ({ row }) => {
+          const current = row.original.requested_action ?? 'NEW HIRE';
+          return (
+            <Select
+              value={current}
+              size="small"
+              variant="standard"
+              disableUnderline
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => {
+                const next = e.target.value as string;
+                firebase
+                  .firestore()
+                  .collection('assignments')
+                  .doc(row.original.id)
+                  .update({ requested_action: next })
+                  .catch(console.error);
+                setAssignments((prev) =>
+                  prev.map((a) =>
+                    a.id === row.original.id
+                      ? { ...a, requested_action: next }
+                      : a
+                  )
+                );
+              }}
+              sx={{
+                fontSize: 13,
+                fontWeight: 500,
+                '& .MuiSelect-select': { py: 0.25 },
+              }}
+            >
+              {['NEW HIRE', 'REAPPOINT', 'TERMINATE', 'LEAVE'].map((opt) => (
+                <MenuItem key={opt} value={opt} sx={{ fontSize: 13 }}>
+                  {opt}
+                </MenuItem>
+              ))}
+            </Select>
+          );
+        },
+        size: 160,
       },
       { id: 'pid', header: 'Project ID', accessorKey: 'pid', size: 110 },
       {


### PR DESCRIPTION
Replaces the hardcoded 'NEW HIRE' value with an inline Select dropdown (NEW HIRE, REAPPOINT, TERMINATE, LEAVE) that saves immediately to Firestore. Also wires the field into the Edit dialog and Excel export.