### PR TITLE
fix(roles): normalize role from Firestore before storing in state

### DIFF
--- a/src/firebase/util/GetUserRole.js
+++ b/src/firebase/util/GetUserRole.js
@@ -38,7 +38,7 @@ const GetUserRole = (userId) => {
   useEffect(() => {
     if (e2e) return;
     const data = snapshot?.data();
-    if (data?.role) setRole(data.role);
+    if (data?.role) setRole(normalizeRole(data.role));
   }, [e2e, snapshot]);
 
   if (e2e) return STUB;


### PR DESCRIPTION
normalizeRole() was only applied to the E2E test stub, so lowercase
'student' stored in Firestore bypassed normalization and failed the
roleMapping lookup, showing 'Not listed' instead of 'Student'.

https://claude.ai/code/session_01FoDfXNSKUFVkYgMbTb5Nii