### PR TITLE
fix(roles): fix student_assigned role showing as Not listed with empty sidebar

### DIFF
--- a/src/firebase/util/GetUserRole.js
+++ b/src/firebase/util/GetUserRole.js
@@ -13,6 +13,7 @@ const normalizeRole = (value) => {
   if (lower === 'student_applied') return 'student_applied';
   if (lower === 'student_accepted') return 'student_accepted';
   if (lower === 'student_denied') return 'student_denied';
+  if (lower === 'student_assigned') return 'student_assigned';
   if (lower === 'faculty') return 'faculty';
   if (lower === 'admin') return 'admin';
   return raw;

--- a/src/firebase/util/GetUserRole.js
+++ b/src/firebase/util/GetUserRole.js
@@ -38,7 +38,7 @@ const GetUserRole = (userId) => {
   useEffect(() => {
     if (e2e) return;
     const data = snapshot?.data();
-    if (data?.role) setRole(data.role);
+    if (data?.role) setRole(normalizeRole(data.role));
   }, [e2e, snapshot]);
 
   if (e2e) return STUB;

--- a/src/hooks/useGetItems.ts
+++ b/src/hooks/useGetItems.ts
@@ -53,7 +53,8 @@ export const getNavItems = (userRole: Role): NavbarItem[] => {
     /* ─────────────────────────────── Student buckets ───────────────────────────── */
     case 'Student':
     case 'student_applied':
-    case 'student_applying': // <- you had "student_applying" in code
+    case 'student_applying':
+    case 'student_assigned':
       return [
         {
           label: 'Applications',
@@ -137,6 +138,7 @@ export const getApplications = (userRole: Role): NavbarItem[] => {
     case 'Student':
     case 'student_applied':
     case 'student_applying':
+    case 'student_assigned':
       return [
         {
           label: 'Course Assistant',
@@ -204,6 +206,7 @@ export const getCourses = (userRole: Role): NavbarItem[] => {
     case 'Student':
     case 'student_applied':
     case 'student_applying':
+    case 'student_assigned':
       return [];
     case 'faculty':
       return [

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -35,7 +35,8 @@ export type Role =
   | 'student_applying'
   | 'student_applied'
   | 'student_accepted'
-  | 'student_denied';
+  | 'student_denied'
+  | 'student_assigned';
 
 export const roleMapping: Record<Role, string> = {
   Student: 'Student',
@@ -46,4 +47,5 @@ export const roleMapping: Record<Role, string> = {
   student_applied: 'Student',
   student_accepted: 'Student (Accepted)',
   student_denied: 'Student (Denied)',
+  student_assigned: 'Student (Assigned)',
 };


### PR DESCRIPTION
## Summary

- When an admin assigns a student to a course, `AssignmentGrid` writes `role: 'student_assigned'` to Firestore. This role was missing from the `Role` type, `roleMapping`, `normalizeRole`, and `getNavItems`, causing assigned students to see "Not listed" in the TopBar and an empty sidebar with no page content.
- Also fixes the root normalization bug where `normalizeRole()` was only applied to the E2E stub and not to values read from Firestore, causing lowercase `'student'` to bypass the `roleMapping` lookup.

## Changes

- `src/types/User.ts` — added `'student_assigned'` to `Role` type and `roleMapping` (displays as "Student (Assigned)")
- `src/firebase/util/GetUserRole.js` — apply `normalizeRole()` to Firestore data (not just E2E stub); add `'student_assigned'` to normalization map
- `src/hooks/useGetItems.ts` — add `'student_assigned'` case to all three switch statements so assigned students get the standard student nav items

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoDfXNSKUFVkYgMbTb5Nii)_